### PR TITLE
Ast actor dcl

### DIFF
--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -119,7 +119,6 @@ statement : boolExp SEMICOLON
 forStatement : sendMsg
     |declaration
     |assignment
-    |arithExp
     ;
 
 // body is a block of code

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -51,7 +51,7 @@ controlStructure : ifElse
     ;
 
 // for loop can take an identifier or declare one and have an evaluation expression and end of loop statement executed at the end of each run through
-forLoop : FOR PARAN_OPEN (identifier | declaration)? SEMICOLON (boolExp | identifier) SEMICOLON forStatement? PARAN_CLOSE body;
+forLoop : FOR PARAN_OPEN (identifier | declaration |assignment)? SEMICOLON (boolExp | identifier) SEMICOLON forStatement? PARAN_CLOSE body;
 //while loop only having a evaluation before each loop
 whileLoop : WHILE PARAN_OPEN (boolExp | identifier) PARAN_CLOSE body;
 
@@ -63,7 +63,11 @@ elsePart : elseIf* ELSE body;
 elseIf : ELSE_IF PARAN_OPEN boolExp PARAN_CLOSE body;
 
 // Declaration used to declare variables
-declaration : (allTypes | identifier)? (identifier (ARRAY_TYPE)? | actorAccess) (ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor))?;
+declaration: allTypes (identifier (ARRAY_TYPE)?) (initialization)?;
+initialization:  ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor);
+
+//assignment used to assign a value to an already defined variable.
+assignment: (identifier|arrayAccess|actorAccess) ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor) SEMICOLON;
 
 // Expression evaluating boolean value of a boolean expression
 boolExp : boolAndExp (LOGIC_OR boolAndExp)*; // OR have lowest logical precedence
@@ -104,15 +108,17 @@ compareOther : GREATER // Other compare operators have same precedence
 statement : boolExp SEMICOLON
     | compareExp SEMICOLON
     | declaration SEMICOLON
+    |assignment SEMICOLON
     | sendMsg SEMICOLON
     | controlStructure
     | methodCall
     | printCall
     ;
 
-//a for loop can only send messages, make a declaration, or make an arithmetic axpression in the lop-end statement
+//a for loop can only send messages, make a declaration or assignment, or make an arithmetic axpression in the lop-end statement
 forStatement : sendMsg
     | declaration
+    |assignment
     ;
 
 // body is a block of code
@@ -139,6 +145,9 @@ arrayAssign : arrayAssignLength
 
 // assignment of the length af an array
 arrayAssignLength : identifier ASSIGN SQUARE_OPEN STRICT_POS_INT SQUARE_CLOSE;
+
+//access array
+arrayAccess : identifier SQUARE_OPEN arithExp SQUARE_CLOSE;
 
 //arbritatry lsit of either ints, doubles, bools, or strings
 list : CURLY_OPEN listItem (COMMA listItem)* CURLY_CLOSE;

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -34,7 +34,7 @@ spawn : SPAWN parameters body;
 // methods of this actor
 actorMethod: onMethod | localMethod;
 onMethod : ON_METHOD  identifier parameters body;
-localMethod: LOCAL_METHOD allTypes identifier parameters body;
+localMethod: LOCAL_METHOD identifier parameters COLON allTypes body;
 
 //Ways to acces either the state of an actor or access the actors known of the current actor
 actorAccess : STATE DOT IDENTIFIER

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -32,7 +32,10 @@ actorKnows : KNOWS CURLY_OPEN (identifier identifier (COMMA identifier identifie
 // defines how to create an instance of this actor type
 spawn : SPAWN parameters body;
 // methods of this actor
-actorMethod : (ON_METHOD | LOCAL_METHOD) identifier parameters body;
+actorMethod: onMethod | localMethod;
+onMethod : ON_METHOD  identifier parameters body;
+localMethod: LOCAL_METHOD allTypes identifier parameters body;
+
 //Ways to acces either the state of an actor or access the actors known of the current actor
 actorAccess : STATE DOT IDENTIFIER
     | KNOWS DOT IDENTIFIER

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -67,7 +67,7 @@ declaration: allTypes (identifier (ARRAY_TYPE)?) (initialization)?;
 initialization:  ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor);
 
 //assignment used to assign a value to an already defined variable.
-assignment: (identifier|arrayAccess|actorAccess) ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor) SEMICOLON;
+assignment: (identifier|arrayAccess|actorAccess) ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor) ;
 
 // Expression evaluating boolean value of a boolean expression
 boolExp : boolAndExp (LOGIC_OR boolAndExp)*; // OR have lowest logical precedence
@@ -117,8 +117,9 @@ statement : boolExp SEMICOLON
 
 //a for loop can only send messages, make a declaration or assignment, or make an arithmetic axpression in the lop-end statement
 forStatement : sendMsg
-    | declaration
+    |declaration
     |assignment
+    |arithExp
     ;
 
 // body is a block of code

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorDclNode.java
@@ -1,0 +1,8 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public class ActorDclNode extends DclNode{
+    public ActorDclNode(String id) {
+        super(id);
+        System.out.println("test");
+    }
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorDclNode.java
@@ -3,6 +3,5 @@ package org.abcd.examples.ParLang.AstNodes;
 public class ActorDclNode extends DclNode{
     public ActorDclNode(String id) {
         super(id);
-        System.out.println("test");
     }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorIdentifierNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorIdentifierNode.java
@@ -1,0 +1,21 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+import org.abcd.examples.ParLang.LanguageType;
+
+public class ActorIdentifierNode extends AstNode{
+    private final String name;
+    private final String actorType;
+
+    public ActorIdentifierNode(String name, String actorType){
+        this.name=name;
+        this.actorType=actorType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getActorType() {
+        return actorType;
+    }
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorStateNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorStateNode.java
@@ -1,5 +1,8 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class ActorStateNode extends AstNode{
+public class ActorStateNode extends DclNode{
 
+    public ActorStateNode(String id) {
+        super(id);
+    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorStateNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ActorStateNode.java
@@ -1,4 +1,5 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class MainDclNode extends AstNode{
+public class ActorStateNode extends AstNode{
+
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ArithExprNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ArithExprNode.java
@@ -20,7 +20,7 @@ public class ArithExprNode extends ExprNode {
 
     private final OpType opType;
 
-    public ArithExprNode(OpType t, ExprNode l, ExprNode r){
+    public ArithExprNode(OpType t, AstNode l, AstNode r){
         opType=t;
         this.addChild(l);
         this.addChild(r);

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ArithExprNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ArithExprNode.java
@@ -1,7 +1,7 @@
 package org.abcd.examples.ParLang.AstNodes;
 
 public class ArithExprNode extends ExprNode {
-    public enum Type {
+    public enum OpType {
         PLUS("+"),
         MINUS("-"),
         MULTIPLY("*"),
@@ -9,7 +9,7 @@ public class ArithExprNode extends ExprNode {
         MODULO("%");
         private final String value;
 
-        Type(String value) {
+        OpType(String value) {
             this.value = value;
         }
 
@@ -18,15 +18,15 @@ public class ArithExprNode extends ExprNode {
         }
     }
 
-    private final Type type;
+    private final OpType opType;
 
-    public ArithExprNode(Type t, ExprNode l, ExprNode r){
-        type=t;
+    public ArithExprNode(OpType t, ExprNode l, ExprNode r){
+        opType=t;
         this.addChild(l);
         this.addChild(r);
     }
 
-    public Type getType() {
-        return type;
+    public OpType getOpType() {
+        return opType;
     }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AssignNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AssignNode.java
@@ -1,0 +1,5 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public class AssignNode extends AstNode{
+
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -15,4 +15,12 @@ public abstract class AstNode {
     public void addChild(AstNode n){
         children.add(n);
     }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -6,7 +6,6 @@ import java.util.List;
 public abstract class AstNode {
 
     private List<AstNode> children = new ArrayList<>();
-    private String type;
 
     public List<AstNode> getChildren() {
         return children;
@@ -16,11 +15,4 @@ public abstract class AstNode {
         children.add(n);
     }
 
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/DclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/DclNode.java
@@ -1,9 +1,9 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public abstract class VarDclNode extends AstNode {
+public abstract class DclNode extends AstNode {
     private String id;
 
-    public VarDclNode(String id){
+    public DclNode(String id){
         this.id = id;
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/DclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/DclNode.java
@@ -10,8 +10,4 @@ public abstract class DclNode extends AstNode {
     public String getId() {
         return id;
     }
-
-    public void setId(String id) {
-        this.id = id;
-    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/IdentifierNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/IdentifierNode.java
@@ -11,6 +11,11 @@ public class IdentifierNode extends AstNode{
         this.type=type;
     }
 
+    public IdentifierNode(String name){
+        this.name=name;
+        this.type=null;
+    }
+
     public String getName() {
         return name;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/InitializationNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/InitializationNode.java
@@ -1,0 +1,4 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public class InitializationNode extends AstNode{
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/KnowsNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/KnowsNode.java
@@ -1,4 +1,4 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class MainDclNode extends AstNode{
+public class KnowsNode extends AstNode{
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/KnowsNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/KnowsNode.java
@@ -1,4 +1,7 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class KnowsNode extends AstNode{
+public class KnowsNode extends DclNode{
+    public KnowsNode(String id) {
+        super(id);
+    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MainDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MainDclNode.java
@@ -1,4 +1,8 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class MainDclNode extends AstNode{
+public class MainDclNode extends DclNode{
+
+    public MainDclNode(String id) {
+        super(id);
+    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
@@ -1,0 +1,22 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public class MethodDclNode extends DclNode{
+
+    private String returnType;
+
+    private String methodType;
+
+    public MethodDclNode(String id, String returnType, String MethodType) {
+        super(id);
+        this.returnType=returnType;
+        this.methodType=methodType;
+    }
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(String returnType) {
+        this.returnType = returnType;
+    }
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
@@ -3,7 +3,6 @@ package org.abcd.examples.ParLang.AstNodes;
 public class MethodDclNode extends DclNode{
 
     private String returnType;
-
     private String methodType;
 
     public MethodDclNode(String id, String returnType, String methodType) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/MethodDclNode.java
@@ -6,11 +6,13 @@ public class MethodDclNode extends DclNode{
 
     private String methodType;
 
-    public MethodDclNode(String id, String returnType, String MethodType) {
+    public MethodDclNode(String id, String returnType, String methodType) {
         super(id);
         this.returnType=returnType;
         this.methodType=methodType;
     }
+
+    public String getMethodType(){return  methodType;}
 
     public String getReturnType() {
         return returnType;

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnDclNode.java
@@ -1,4 +1,4 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class SpawnNode extends AstNode{
+public class SpawnDclNode extends AstNode{
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnNode.java
@@ -1,4 +1,4 @@
 package org.abcd.examples.ParLang.AstNodes;
 
-public class MainDclNode extends AstNode{
+public class SpawnNode extends AstNode{
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
@@ -1,0 +1,14 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+import org.abcd.examples.ParLang.LanguageType;
+
+public class VarDclNode extends DclNode{
+    private final LanguageType type;
+    public VarDclNode(String id, LanguageType type) {
+        super(id);
+        this.type=type;
+    }
+    public LanguageType getType() {
+        return type;
+    }
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
@@ -1,0 +1,17 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public abstract class VarDclNode extends AstNode {
+    private String id;
+
+    public VarDclNode(String id){
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -20,7 +20,11 @@ public class AstPrintVisitor {
                     this.print(localIndent, className + " with "+  ((ParametersNode)node).getNumberOfIdentifiers() + " identifier(s)");
                     break;
                 case "IdentifierNode":
-                    this.print(localIndent, className + " with type: " + ((IdentifierNode)node).getType().toString() + " and identifier: " + ((IdentifierNode)node).getName());
+                    if(((IdentifierNode)node).getType()!=null){
+                        this.print(localIndent, className + " with type: " + ((IdentifierNode)node).getType().toString() + " and identifier: " + ((IdentifierNode)node).getName());
+                    }else{
+                        this.print(localIndent, className + " with identifier: " + ((IdentifierNode)node).getName());
+                    }
                     break;
                 case "ActorIdentifierNode":
                     this.print(localIndent, className + " with type: " + ((ActorIdentifierNode)node).getActorType()+ " and identifier: " + ((ActorIdentifierNode)node).getName());
@@ -30,6 +34,10 @@ public class AstPrintVisitor {
                     break;
                 case "ActorDclNode":
                     this.print(localIndent, className + " with the id: " + ((ActorDclNode)node).getId());
+                    break;
+
+                case "MethodDclNode":
+                    this.print(localIndent, className + " - id: " + ((MethodDclNode)node).getId()+ ", method type : "+ ((MethodDclNode)node).getMethodType()+", return type: "+((MethodDclNode)node).getReturnType());
                     break;
                 default:
                     this.print(localIndent, className);

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -5,33 +5,34 @@ import org.abcd.examples.ParLang.AstNodes.*;
 public class AstPrintVisitor {
     public void visit(int localIndent, AstNode node){
         if(node != null){
-            switch (node.getClass().toString()){
-                case "class org.abcd.examples.ParLang.AstNodes.ArithExpression":
-                    this.print(localIndent, node.getClass() + " of type: " + ((ArithExprNode) node).getOpType());
+            String className=node.getClass().getSimpleName();
+            switch (className){
+                case "ArithExprNode":
+                    this.print(localIndent, className + " of type: " + ((ArithExprNode) node).getOpType());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.DoubleNode":
-                    this.print(localIndent, node.getClass() + " with the value: " + ((DoubleNode)node).getValue());
+                case "DoubleNode":
+                    this.print(localIndent, className + " with the value: " + ((DoubleNode)node).getValue());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.IntegerNode":
-                    this.print(localIndent, node.getClass() + " with the value: " + ((IntegerNode)node).getValue());
+                case "IntegerNode":
+                    this.print(localIndent, className + " with the value: " + ((IntegerNode)node).getValue());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.ParametersNode":
-                    this.print(localIndent, node.getClass() + " with "+  ((ParametersNode)node).getNumberOfIdentifiers() + " identifiers");
+                case "ParametersNode":
+                    this.print(localIndent, className + " with "+  ((ParametersNode)node).getNumberOfIdentifiers() + " identifier(s)");
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.IdentifierNode":
-                    this.print(localIndent, node.getClass() + " with type " + ((IdentifierNode)node).getType().toString() + " and identifier: " + ((IdentifierNode)node).getName());
+                case "IdentifierNode":
+                    this.print(localIndent, className + " with type: " + ((IdentifierNode)node).getType().toString() + " and identifier: " + ((IdentifierNode)node).getName());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.ActorIdentifierNode":
-                    this.print(localIndent, node.getClass() + " with type " + ((ActorIdentifierNode)node).getActorType()+ " and identifier: " + ((ActorIdentifierNode)node).getName());
+                case "ActorIdentifierNode":
+                    this.print(localIndent, className + " with type: " + ((ActorIdentifierNode)node).getActorType()+ " and identifier: " + ((ActorIdentifierNode)node).getName());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.StringNode":
-                    this.print(localIndent, node.getClass() + "with the value: " + ((StringNode)node).getValue());
+                case "StringNode":
+                    this.print(localIndent, className + " with the value: " + ((StringNode)node).getValue());
                     break;
-                case "class org.abcd.examples.ParLang.AstNodes.ActorDclNode":
-                    this.print(localIndent, node.getClass() + "with the id: " + ((ActorDclNode)node).getId());
+                case "ActorDclNode":
+                    this.print(localIndent, className + " with the id: " + ((ActorDclNode)node).getId());
                     break;
                 default:
-                    this.print(localIndent, node.getClass().toString());
+                    this.print(localIndent, className);
                     break;
             }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -7,7 +7,7 @@ public class AstPrintVisitor {
         if(node != null){
             switch (node.getClass().toString()){
                 case "class org.abcd.examples.ParLang.AstNodes.ArithExpression":
-                    this.print(localIndent, node.getClass() + " of type: " + ((ArithExprNode) node).getType());
+                    this.print(localIndent, node.getClass() + " of type: " + ((ArithExprNode) node).getOpType());
                     break;
                 case "class org.abcd.examples.ParLang.AstNodes.DoubleNode":
                     this.print(localIndent, node.getClass() + " with the value: " + ((DoubleNode)node).getValue());

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -37,7 +37,7 @@ public class AstPrintVisitor {
                     break;
 
                 case "MethodDclNode":
-                    this.print(localIndent, className + " - id: " + ((MethodDclNode)node).getId()+ ", method type : "+ ((MethodDclNode)node).getMethodType()+", return type: "+((MethodDclNode)node).getReturnType());
+                    this.print(localIndent, className + " with id: " + ((MethodDclNode)node).getId()+ ", method type: "+ ((MethodDclNode)node).getMethodType()+" and return type: "+((MethodDclNode)node).getReturnType());
                     break;
                 default:
                     this.print(localIndent, className);

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -24,6 +24,9 @@ public class AstPrintVisitor {
                 case "class org.abcd.examples.ParLang.AstNodes.StringNode":
                     this.print(localIndent, node.getClass() + "with the value: " + ((StringNode)node).getValue());
                     break;
+                case "class org.abcd.examples.ParLang.AstNodes.ActorDclNode":
+                    this.print(localIndent, node.getClass() + "with the id: " + ((ActorDclNode)node).getId());
+                    break;
                 default:
                     this.print(localIndent, node.getClass().toString());
                     break;

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -19,7 +19,10 @@ public class AstPrintVisitor {
                     this.print(localIndent, node.getClass() + " with "+  ((ParametersNode)node).getNumberOfIdentifiers() + " identifiers");
                     break;
                 case "class org.abcd.examples.ParLang.AstNodes.IdentifierNode":
-                    this.print(localIndent, node.getClass() + " with " + ((IdentifierNode)node).getType().toString() + " identifier: " + ((IdentifierNode)node).getName());
+                    this.print(localIndent, node.getClass() + " with type " + ((IdentifierNode)node).getType().toString() + " and identifier: " + ((IdentifierNode)node).getName());
+                    break;
+                case "class org.abcd.examples.ParLang.AstNodes.ActorIdentifierNode":
+                    this.print(localIndent, node.getClass() + " with type " + ((ActorIdentifierNode)node).getActorType()+ " and identifier: " + ((ActorIdentifierNode)node).getName());
                     break;
                 case "class org.abcd.examples.ParLang.AstNodes.StringNode":
                     this.print(localIndent, node.getClass() + "with the value: " + ((StringNode)node).getValue());

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -19,7 +19,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 continue;
             }
             //print can be used for debugging
-            System.out.println(c.getText());
+            //System.out.println(c.getText());
             node.addChild( visit(c));
         }
         return node;

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -123,12 +123,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
         ParLangParser.InitializationContext init=ctx.initialization();
         if(init!=null){//variable is initialized
-            AssignNode assignNode=new AssignNode();
-
-            assignNode.addChild(idNode);
-            assignNode.addChild(visit(init.getChild(1)));
-
-            dclNode.addChild(assignNode); //add initialized value as child
+            InitializationNode initializationNode=new InitializationNode();
+            initializationNode.addChild(visit(init.getChild(1)));
+            dclNode.addChild(initializationNode); //add initializationNode as child
         }
         return dclNode;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -7,7 +7,6 @@ import org.abcd.examples.ParLang.AstNodes.*;
 public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitInit(ParLangParser.InitContext ctx) {
         InitNode initNode=new InitNode();
-
         return childVisitor(initNode,ctx.children.toArray(ParseTree[]::new));
     }
 
@@ -25,7 +24,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         MainDclNode main= new MainDclNode();
 
         if(!ctx.parameters().getText().equals("()")){
-            main.addChild(visit(ctx.parameters()));//arguments not handled yet. The idea is to have arguments as children to the main node.
+            main.addChild(visit(ctx.parameters()));//parameters not handled yet. The idea is to have arguments as children to the main node.
         }
         if(ctx.body()!=null){
             main.addChild(visit(ctx.body()));
@@ -34,10 +33,59 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     }
 
     @Override public AstNode visitActor(ParLangParser.ActorContext ctx) {
-
-
-        return this.visitChildren(ctx);
+        System.out.println("visit Actor");
+        ActorDclNode node=new ActorDclNode(ctx.identifier().getText());
+        return childVisitor(node,ctx.children.toArray(ParseTree[]::new));
     }
+
+    @Override public AstNode visitActorState(ParLangParser.ActorStateContext ctx) {
+        ActorStateNode node= new ActorStateNode();
+
+        return childVisitor(node,ctx.children.toArray(ParseTree[]::new));
+    }
+
+    @Override public AstNode visitActorKnows(ParLangParser.ActorKnowsContext ctx) {
+        System.out.println("visiting knows?");
+        KnowsNode node= new KnowsNode();
+
+        return childVisitor(node,ctx.children.toArray(ParseTree[]::new));
+    }
+
+    @Override public AstNode visitSpawn(ParLangParser.SpawnContext ctx) {
+        SpawnNode node= new SpawnNode();
+
+        if(!ctx.parameters().getText().equals("()")){
+            node.addChild(visit(ctx.parameters()));//parameters not handled yet. The idea is to have arguments as children to the main node.
+        }
+        if(ctx.body()!=null){
+            node.addChild(visit(ctx.body()));
+        }
+        return node;
+    }
+
+    @Override public AstNode visitOnMethod(ParLangParser.OnMethodContext ctx) {
+        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),"void","on");
+        if (ctx.parameters() != null) {
+            node.addChild(visit(ctx.parameters()));
+        }
+        if(ctx.body()!=null){
+            node.addChild(visit(ctx.body()));
+        }
+        return node;
+    }
+
+
+    @Override public AstNode visitLocalMethod(ParLangParser.LocalMethodContext ctx) {
+        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),ctx.allTypes().getText(),"local");
+        if (ctx.parameters() != null) {
+            node.addChild(visit(ctx.parameters()));
+        }
+        if(ctx.body()!=null){
+            node.addChild(visit(ctx.body()));
+        }
+        return node;
+    }
+
 
     @Override public AstNode visitBody(ParLangParser.BodyContext ctx) {
         BodyNode bodyNode =new BodyNode();

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -19,7 +19,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 continue;
             }
             //print can be used for debugging
-            //System.out.println(c.getText());
+            System.out.println(c.getText());
             node.addChild( visit(c));
         }
         return node;
@@ -62,8 +62,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     }
 
     @Override public AstNode visitActorKnows(ParLangParser.ActorKnowsContext ctx) {
-        KnowsNode node= new KnowsNode();
-        return childVisitor(node,ctx.children);
+        int numOfChildren=ctx.getChildCount();
+        KnowsNode knowsNode= new KnowsNode();
+        if (numOfChildren != 3){ //there are minimum 3 children, the parentheses and "knows" token
+            //If there are more than 3 children, there are known actors
+            for (int i = 2; i < numOfChildren; i+=3){
+                System.out.println("her: "+ctx.getChild(i+1).getText());
+                knowsNode.addChild(new ActorIdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText()));
+            }
+        }
+        return knowsNode;
     }
 
     @Override public AstNode visitSpawn(ParLangParser.SpawnContext ctx) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -123,13 +123,13 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         int nextOperator=operatorIndex+2;
 
         ArithExprNode.OpType operator=getArithmeticBinaryOperator(child.getText());
-        ExprNode leftChild=(ExprNode) visit(parent.term(termIndex));
-        ExprNode rightChild;
+        AstNode leftChild= visit(parent.term(termIndex));
+        AstNode rightChild;
 
         if(parent.getChild(nextOperator)!= null){ //Are there more operators in the tree?
-            rightChild=(ExprNode)visitArithExpChild(parent.getChild(nextOperator),parent,nextOperator);
+            rightChild=visitArithExpChild(parent.getChild(nextOperator),parent,nextOperator);
         }else {
-            rightChild=(ExprNode)  visit(parent.term(termIndex+1));
+            rightChild=visit(parent.term(termIndex+1));
         }
         return new ArithExprNode(operator,leftChild,rightChild);
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -19,14 +19,14 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 continue;
             }
             //print can be used for debugging
-            System.out.println(c.getText());
+            //System.out.println(c.getText());
             node.addChild( visit(c));
         }
         return node;
     }
 
     @Override public AstNode visitMainFunc(ParLangParser.MainFuncContext ctx) {
-        MainDclNode main= new MainDclNode();
+        MainDclNode main= new MainDclNode(ctx.MAIN().getText());
 
         if(!ctx.parameters().getText().equals("()")){
             main.addChild(visit(ctx.parameters()));//parameters not handled yet. The idea is to have arguments as children to the main node.
@@ -57,17 +57,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     }
 
     @Override public AstNode visitActorState(ParLangParser.ActorStateContext ctx) {
-        ActorStateNode node= new ActorStateNode();
+        ActorStateNode node= new ActorStateNode(ctx.STATE().getText());
         return childVisitor(node,ctx.children);
     }
 
     @Override public AstNode visitActorKnows(ParLangParser.ActorKnowsContext ctx) {
         int numOfChildren=ctx.getChildCount();
-        KnowsNode knowsNode= new KnowsNode();
+        KnowsNode knowsNode= new KnowsNode(ctx.KNOWS().getText());
         if (numOfChildren != 3){ //there are minimum 3 children, the parentheses and "knows" token
             //If there are more than 3 children, there are known actors
             for (int i = 2; i < numOfChildren; i+=3){
-                System.out.println("her: "+ctx.getChild(i+1).getText());
                 knowsNode.addChild(new ActorIdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText()));
             }
         }
@@ -86,7 +85,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     }
 
     @Override public AstNode visitOnMethod(ParLangParser.OnMethodContext ctx) {
-        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),"void","on");
+        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),"void",ctx.ON_METHOD().getText());
         if (ctx.parameters() != null) {
             node.addChild(visit(ctx.parameters()));
         }
@@ -98,7 +97,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
 
     @Override public AstNode visitLocalMethod(ParLangParser.LocalMethodContext ctx) {
-        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),ctx.allTypes().getText(),"local");
+        MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),ctx.allTypes().getText(),ctx.LOCAL_METHOD().getText());
         if (ctx.parameters() != null) {
             node.addChild(visit(ctx.parameters()));
         }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -19,7 +19,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 continue;
             }
             //print can be used for debugging
-            //System.out.println(c.getText());
+            System.out.println(c.getText());
             node.addChild( visit(c));
         }
         return node;
@@ -112,6 +112,17 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitBody(ParLangParser.BodyContext ctx) {
         BodyNode bodyNode =new BodyNode();
         return childVisitor(bodyNode,ctx.children);
+    }
+
+    @Override
+    public AstNode visitDeclaration(ParLangParser.DeclarationContext ctx) {
+        VarDclNode dclNode=new VarDclNode(ctx.identifier().getText(),LanguageType.valueOf(ctx.allTypes().getText().toUpperCase()));
+        dclNode.addChild(new IdentifierNode(ctx.identifier().getText(),LanguageType.valueOf(ctx.allTypes().getText().toUpperCase()))); //add identifier as child
+        ParLangParser.InitializationContext init=ctx.initialization();
+        if(init!=null){//variable is initialized
+            dclNode.addChild( visit(init.getChild(1))); //add initialized value as child
+        }
+        return dclNode;
     }
 
     @Override public AstNode visitStatement(ParLangParser.StatementContext ctx) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -33,6 +33,12 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         return main;
     }
 
+    @Override public AstNode visitActor(ParLangParser.ActorContext ctx) {
+
+
+        return this.visitChildren(ctx);
+    }
+
     @Override public AstNode visitBody(ParLangParser.BodyContext ctx) {
         BodyNode bodyNode =new BodyNode();
         return childVisitor(bodyNode,ctx.children.toArray(ParseTree[]::new));
@@ -55,7 +61,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         int termIndex=(operatorIndex-1)/2; //index of first term in a list of just the terms (not including operators).
         int nextOperator=operatorIndex+2;
 
-        ArithExprNode.Type operator=getArithmeticBinaryOperator(child.getText());
+        ArithExprNode.OpType operator=getArithmeticBinaryOperator(child.getText());
         ExprNode leftChild=(ExprNode) visit(parent.term(termIndex));
         ExprNode rightChild;
 
@@ -82,7 +88,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         int factorIndex=(operatorIndex-1)/2; //index of first factor in a list of just the factors
         int nextOperator=operatorIndex+2;
 
-        ArithExprNode.Type operator=getArithmeticBinaryOperator(child.getText());
+        ArithExprNode.OpType operator=getArithmeticBinaryOperator(child.getText());
         ExprNode leftChild=(ExprNode) visit(parent.factor(factorIndex));
         ExprNode rightChild;
 
@@ -120,18 +126,18 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         return new IntegerNode(Integer.parseInt(ctx.getText()));
     }
 
-    private static ArithExprNode.Type getArithmeticBinaryOperator(String operator) {
+    private static ArithExprNode.OpType getArithmeticBinaryOperator(String operator) {
         switch (operator) {
             case "+":
-                return ArithExprNode.Type.PLUS;
+                return ArithExprNode.OpType.PLUS;
             case  "-":
-                return ArithExprNode.Type.MINUS;
+                return ArithExprNode.OpType.MINUS;
             case "*":
-                return ArithExprNode.Type.MULTIPLY;
+                return ArithExprNode.OpType.MULTIPLY;
             case "/":
-                return ArithExprNode.Type.DIVIDE;
+                return ArithExprNode.OpType.DIVIDE;
             case "%":
-                return ArithExprNode.Type.MODULO;
+                return ArithExprNode.OpType.MODULO;
             default:
                 throw new UnsupportedOperationException("Unsupported operator: " + operator);
         }


### PR DESCRIPTION
changes to AstVisitor and AstPrintVisitor, creation of AST Node classes, and some changes to the grammar. 

- Actor declaration: can declare with all internal parts (State, Knows, etc.)
- ActorIdentifierNode: Introduced for the actors declared in Knows. 
- Variable declaration (primitives): itdentifier (identifierNode) is first child, if there is initialization then the initialization value is second child.  
- Assingment: Identifier is first child and the value assigned to the identifier is second child. 
- Method declaration (on and local - local has return type): MethodDclNode used for boto on an local. 
- Spawn Declaration
- Changes to grammar: actormethod and declaration changed. 

