### PR TITLE
Ast array declare

### DIFF
--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -65,11 +65,11 @@ elsePart : elseIf* ELSE body;
 elseIf : ELSE_IF PARAN_OPEN boolExp PARAN_CLOSE body;
 
 // Declaration used to declare variables
-declaration: allTypes (identifier (ARRAY_TYPE)?) (initialization)?;
-initialization:  ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor);
+declaration: allTypes identifier (initialization)?;
+initialization:  ASSIGN (arithExp | primitive | list | identifier | actorAccess | spawnActor);
 
 //assignment used to assign a value to an already defined variable.
-assignment: (identifier|arrayAccess|actorAccess) ASSIGN (arithExp | primitive | arrayAssign | identifier | actorAccess | spawnActor) ;
+assignment: (identifier|arrayAccess|actorAccess) ASSIGN (arithExp | primitive | list | identifier | actorAccess | spawnActor) ;
 
 // Expression evaluating boolean value of a boolean expression
 boolExp : boolAndExp (LOGIC_OR boolAndExp)*; // OR have lowest logical precedence
@@ -139,15 +139,6 @@ methodCall : identifier arguments;
 
 // to instanziate a new actor of a defined type
 spawnActor : SPAWN identifier arguments;
-
-// can define the length of the array or specify the array elements in between curly braces
-arrayAssign : arrayAssignLength
-    | list
-    ;
-
-// assignment of the length af an array
-arrayAssignLength : identifier ASSIGN SQUARE_OPEN STRICT_POS_INT SQUARE_CLOSE;
-
 //access array
 arrayAccess : identifier SQUARE_OPEN arithExp SQUARE_CLOSE;
 

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -61,7 +61,7 @@ whileLoop : WHILE PARAN_OPEN (boolExp) PARAN_CLOSE body;
 selection : IF PARAN_OPEN boolExp PARAN_CLOSE body (ELSE (selection|body))?;
 
 // Declaration used to declare variables
-declaration: allTypes identifier (initialization)?;
+declaration: allTypes identifier (initialization)?; //array type is included in allTypes
 initialization:  ASSIGN (arithExp | primitive | list | identifier | actorAccess | spawnActor);
 
 //assignment used to assign a value to an already defined variable.

--- a/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
+++ b/generator/src/main/antlr4/org/abcd/examples/ParLang/ParLang.g4
@@ -147,10 +147,7 @@ arrayAccess : identifier SQUARE_OPEN arithExp SQUARE_CLOSE;
 list : CURLY_OPEN listItem (COMMA listItem)* CURLY_CLOSE;
 
 // items that can be listed
-listItem : number
-    | STRING
-    | identifier
-    | boolLiteral
+listItem : value //alternatively "primitive | identifier" instead of value if we dont want somehting like "2+2" as element in an integer array.
     | list
     ;
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -6,13 +6,6 @@ import java.util.List;
 public abstract class AstNode {
 
     private List<AstNode> children = new ArrayList<>();
-    private AstNode parent;
-
-    public AstNode getParent() {
-        return parent;
-    }
-
-
     public List<AstNode> getChildren() {
         return children;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -6,6 +6,12 @@ import java.util.List;
 public abstract class AstNode {
 
     private List<AstNode> children = new ArrayList<>();
+    private AstNode parent;
+
+    public AstNode getParent() {
+        return parent;
+    }
+
 
     public List<AstNode> getChildren() {
         return children;

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ListNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ListNode.java
@@ -1,0 +1,4 @@
+package org.abcd.examples.ParLang.AstNodes;
+
+public class ListNode extends AstNode{
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -328,7 +328,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         if(ctx.STRING() != null) {
             return new StringNode(ctx.getText());
         }
-        return null;
+        return visitChildren(ctx);
     }
 
     @Override public AstNode visitArrayAccess(ParLangParser.ArrayAccessContext ctx){

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -167,7 +167,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         ParLangParser.InitializationContext init=ctx.initialization();
         if(init!=null){//variable is initialized
             InitializationNode initializationNode=new InitializationNode();
-            initializationNode.addChild(visit(init.getChild(1)));//child with index 1 is the initialization value.
+            initializationNode.addChild(visit(init.getChild(1)));//child with index 1 is the initialization value (value can also be a list).
             dclNode.addChild(initializationNode); //add initializationNode as child
         }
         return dclNode;

--- a/generator/src/main/java/org/abcd/examples/ParLang/Exceptions/DuplicateActorTypeException.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/Exceptions/DuplicateActorTypeException.java
@@ -1,0 +1,8 @@
+package org.abcd.examples.ParLang.Exceptions;
+import org.antlr.v4.runtime.RecognitionException;
+
+public class DuplicateActorTypeException extends RuntimeException{
+    public DuplicateActorTypeException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
-Fix to array declaration in grammar
-typeContainer is extended with new types when actors are declared
-Exception is thrown if an actor is declared with a name already existing intypeContainer. 
-New type of node to AST: ListNode 
-When a an array is initialized to a list (e.g. int[] a={1,2,3}), ListNode is included as child under the InitializationNode. This allows us to distinguish between e.g. the integer 2 and the list {2} being assigned to the array. I actually found out how to add children of the list directly to the Initialization node; in visitDeclaration one can access the elements in the list as ctx.initialisation().list(). So it can be done, but I think we actually need the ListNode. 