### PR TITLE
Ast node parent field

### DIFF
--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -15,7 +15,8 @@ public abstract class AstNode {
     }
 
     public void addChild(AstNode n){
-        children.add(n);
+        children.add(n); // add n as child to this AstNode
+        n.setParent(this); // set this AstNode as parent to n
     }
 
     public void setParent(AstNode parent) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -9,12 +9,21 @@ import java.util.Objects;
 
 public abstract class AstNode {
     private List<AstNode> children = new ArrayList<>();
+    private AstNode parent;
     public List<AstNode> getChildren() {
         return children;
     }
 
     public void addChild(AstNode n){
         children.add(n);
+    }
+
+    public void setParent(AstNode parent) {
+        this.parent = parent;
+    }
+
+    public AstNode getParent() {
+        return parent;
     }
 
     //Generates a hash code based on the memory address of the object

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/BoolNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/BoolNode.java
@@ -1,7 +1,14 @@
 package org.abcd.examples.ParLang.AstNodes;
 
+import org.abcd.examples.ParLang.NodeVisitor;
+
 public class BoolNode extends LiteralNode<Boolean>{
     public BoolNode(boolean value){
         super(value);
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/CompareExpNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/CompareExpNode.java
@@ -1,5 +1,7 @@
 package org.abcd.examples.ParLang.AstNodes;
 
+import org.abcd.examples.ParLang.NodeVisitor;
+
 public class CompareExpNode extends AstNode {
     private final String operator;
 
@@ -11,6 +13,13 @@ public class CompareExpNode extends AstNode {
     public String getOperator() {
         return operator;
     }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+
 
 }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/NegatedBoolNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/NegatedBoolNode.java
@@ -1,7 +1,14 @@
 package org.abcd.examples.ParLang.AstNodes;
 
+import org.abcd.examples.ParLang.NodeVisitor;
+
 public class NegatedBoolNode extends AstNode {
         public NegatedBoolNode() {
             super();
         }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SendMsgNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SendMsgNode.java
@@ -1,5 +1,7 @@
 package org.abcd.examples.ParLang.AstNodes;
 
+import org.abcd.examples.ParLang.NodeVisitor;
+
 public class SendMsgNode extends AstNode{
 
     private final String msgName;
@@ -16,5 +18,10 @@ public class SendMsgNode extends AstNode{
 
     public String getReceiver(){
         return this.receiver;
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -6,6 +6,10 @@ public class AstPrintVisitor {
     public void visit(int localIndent, AstNode node){
         if(node != null){
             String className=node.getClass().getSimpleName();
+            if(node.getParent()!=null){
+                String parent=node.getParent().getClass().getSimpleName();
+                className+=" (parent: "+parent+") ";
+            }
             switch (className){
                 case "ArithExprNode":
                     this.print(localIndent, className + " : " + ((ArithExprNode) node).getOpType());

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -4,6 +4,9 @@ import org.abcd.examples.ParLang.AstNodes.*;
 
 public class AstPrintVisitor {
 
+    public static final String ANSI_RED = "\u001B[31m"; //for printing red text to the terminal
+    public static final String ANSI_RESET = "\u001B[0m"; //for stopping to print red text.
+
     /***
      *
      * @param localIndent number of \t before information about the AstNode is printed. Shows the depth of the AstNode in the AST.
@@ -16,7 +19,7 @@ public class AstPrintVisitor {
             String className=node.getClass().getSimpleName();
 
             if(printParentField.equals("1")){
-                className+=" "+node.getNodeHash();// print hashcode for each node in order to compare with hash code of the object in the parent fields of the children.
+                className+=" "+ANSI_RED+node.getNodeHash()+ANSI_RESET;// print hashcode for each node in red in order to compare with hash code of the AstNode-object in the parent fields of the children.
                 if(node.getParent()!=null){//only attempt to getClass if parent is not null (parent should only be null for the InitNode)
                     AstNode parent=node.getParent();//get the AstNode stored in the parent field of node.
                     className+=" (parent: "+parent.getClass().getSimpleName()+" "+parent.getNodeHash()+") ";//concatanate parent's className and hashCode to the string printed for node

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -3,22 +3,20 @@ package org.abcd.examples.ParLang;
 import org.abcd.examples.ParLang.AstNodes.*;
 
 public class AstPrintVisitor {
-
-    public static final String ANSI_RED = "\u001B[31m"; //for printing red text to the terminal
-    public static final String ANSI_RESET = "\u001B[0m"; //for stopping to print red text.
-
+    public static final String ANSI_RED = "\u001B[31m"; //include in string to start printing red text to the terminal
+    public static final String ANSI_RESET = "\u001B[0m"; //include in string to stop printing in special color.
     /***
      *
-     * @param localIndent number of \t before information about the AstNode is printed. Shows the depth of the AstNode in the AST.
-     * @param node //an AstNode in the AST.
-     * @param printParentField value given to main as argument. If it is "1", then information about the AstNode assigned to node's parent field is printed.
+     * @param localIndent is the number of "\t" before information about the AstNode is printed. Shows the depth of the AstNode in the AST.
+     * @param node is an AstNode in the AST.
+     * @param printParentField is a string given to main as argument. If it is "parents", then information about the AstNode assigned to node's parent field is printed.
      */
     public void visit(int localIndent, AstNode node, String printParentField){
 
         if(node != null){
             String className=node.getClass().getSimpleName();
 
-            if(printParentField.equals("1")){
+            if(printParentField.equals("parents")){
                 className+=" "+ANSI_RED+node.getNodeHash()+ANSI_RESET;// print hashcode for each node in red in order to compare with hash code of the AstNode-object in the parent fields of the children.
                 if(node.getParent()!=null){//only attempt to getClass if parent is not null (parent should only be null for the InitNode)
                     AstNode parent=node.getParent();//get the AstNode stored in the parent field of node.

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -3,13 +3,26 @@ package org.abcd.examples.ParLang;
 import org.abcd.examples.ParLang.AstNodes.*;
 
 public class AstPrintVisitor {
-    public void visit(int localIndent, AstNode node){
+
+    /***
+     *
+     * @param localIndent number of \t before information about the AstNode is printed. Shows the depth of the AstNode in the AST.
+     * @param node //an AstNode in the AST.
+     * @param printParentField value given to main as argument. If it is "1", then information about the AstNode assigned to node's parent field is printed.
+     */
+    public void visit(int localIndent, AstNode node, String printParentField){
+
         if(node != null){
             String className=node.getClass().getSimpleName();
-            if(node.getParent()!=null){
-                String parent=node.getParent().getClass().getSimpleName();
-                className+=" (parent: "+parent+") ";
+
+            if(printParentField.equals("1")){
+                className+=" "+node.getNodeHash();// print hashcode for each node in order to compare with hash code of the object in the parent fields of the children.
+                if(node.getParent()!=null){//only attempt to getClass if parent is not null (parent should only be null for the InitNode)
+                    AstNode parent=node.getParent();//get the AstNode stored in the parent field of node.
+                    className+=" (parent: "+parent.getClass().getSimpleName()+" "+parent.getNodeHash()+") ";//concatanate parent's className and hashCode to the string printed for node
+                }
             }
+
             switch (className){
                 case "ArithExprNode":
                     this.print(localIndent, className + " : " + ((ArithExprNode) node).getOpType());
@@ -96,7 +109,7 @@ public class AstPrintVisitor {
             }
 
             for (AstNode childNode : node.getChildren()){
-                this.visit(localIndent + 1, childNode);
+                this.visit(localIndent + 1, childNode, printParentField);
             }
         }else{
             System.out.println("A null-node");
@@ -112,7 +125,6 @@ public class AstPrintVisitor {
         } else{
             output = new StringBuilder(output.toString().concat("null"));
         }
-
         System.out.println(output);
     }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -27,7 +27,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
             if(c.getPayload() instanceof CommonToken){
                 continue; //if child is a CommonToken, e.g. "{", then skip.
             }
-            node.addChild(visit(c)); //visit the child and add it to the node
+            AstNode astChild=visit(c);
+            astChild.setParent(node);
+            node.addChild(astChild); //visit the child and add it to the node
         }
         return node; //return the node with all children added
     }
@@ -35,11 +37,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitMainFunc(ParLangParser.MainFuncContext ctx) {
         //Main function is the entry point of the program
         MainDclNode main= new MainDclNode(ctx.MAIN().getText());
+        AstNode mainChild;
         if(!ctx.parameters().getText().equals("()")){ //If there are parameters
-            main.addChild(visit(ctx.parameters())); //add parameters as children to the main node
+            mainChild=visit(ctx.parameters());
+            mainChild.setParent(main);
+            main.addChild(mainChild); //add parameters as children to the main node
         }
         if(ctx.body()!=null){ //If there is a body
-            main.addChild(visit(ctx.body())); //visit the body and add it as a child to the main node
+            mainChild=visit(ctx.body());
+            mainChild.setParent(main);
+            main.addChild(mainChild); //visit the body and add it as a child to the main node
         }
         return main;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -428,8 +428,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitReturnStatement(ParLangParser.ReturnStatementContext ctx){
         ReturnStatementNode returnStatementNode = new ReturnStatementNode();
-        if(ctx.getChild(1) != null){ //If there is a return value
-            returnStatementNode.addChild(visit(ctx.getChild(1)));
+        if(ctx.returnType() != null){ //If there is a return value
+            returnStatementNode.addChild(visit(ctx.returnType()));
         }
         return returnStatementNode; //return the returnStatementNode with the return value added as a child
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -27,9 +27,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
             if(c.getPayload() instanceof CommonToken){
                 continue; //if child is a CommonToken, e.g. "{", then skip.
             }
-            AstNode astChild=visit(c);
-            astChild.setParent(node);
-            node.addChild(astChild); //visit the child and add it to the node
+            node.addChild(visit(c)); //visit the child and add it to the node
         }
         return node; //return the node with all children added
     }
@@ -39,14 +37,10 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         MainDclNode main= new MainDclNode(ctx.MAIN().getText());
         AstNode mainChild;
         if(!ctx.parameters().getText().equals("()")){ //If there are parameters
-            mainChild=visit(ctx.parameters());
-            mainChild.setParent(main);
-            main.addChild(mainChild); //add parameters as children to the main node
+            main.addChild(visit(ctx.parameters())); //add parameters as children to the main node
         }
         if(ctx.body()!=null){ //If there is a body
-            mainChild=visit(ctx.body());
-            mainChild.setParent(main);
-            main.addChild(mainChild); //visit the body and add it as a child to the main node
+            main.addChild(visit(ctx.body())); //visit the body and add it as a child to the main node
         }
         return main;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -35,7 +35,6 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitMainFunc(ParLangParser.MainFuncContext ctx) {
         //Main function is the entry point of the program
         MainDclNode main= new MainDclNode(ctx.MAIN().getText());
-        AstNode mainChild;
         if(!ctx.parameters().getText().equals("()")){ //If there are parameters
             main.addChild(visit(ctx.parameters())); //add parameters as children to the main node
         }
@@ -114,7 +113,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 returnType = null;
         }
         ScriptMethodNode node = new ScriptMethodNode(ctx.identifier().getText(), returnType, methodType);
-        node.addChild(visit(ctx.parameters())); //add parameters as children
+        if(!ctx.parameters().getText().equals("()")){ //If there are parameters
+            node.addChild(visit(ctx.parameters())); //add parameters as children
+        }
         return node; //return the node
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/NodeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/NodeVisitor.java
@@ -5,6 +5,7 @@ import org.abcd.examples.ParLang.AstNodes.*;
 public interface NodeVisitor {
     void visitChildren(AstNode node);
 
+    void visit(SendMsgNode node);
     void visit(InitNode node);
     void visit(BodyNode node);
     void visit(SelectionNode node);

--- a/generator/src/main/java/org/abcd/examples/ParLang/NodeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/NodeVisitor.java
@@ -43,6 +43,9 @@ public interface NodeVisitor {
     void visit(DoubleNode node);
     void visit(StringNode node);
     void visit(ArithExprNode node);
+    void visit(NegatedBoolNode node);
+    void visit(BoolNode node);
+    void visit(CompareExpNode node);
 
     void visit(IterationNode node);
     void visit(WhileNode node);

--- a/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
@@ -24,7 +24,7 @@ import org.abcd.examples.ParLang.AstNodes.AstNode;
 public class ParLang {
     /***
      *
-     * @param args running main with "1" as args[0] tells AstPrintVisitor to print AstNodes with information about parent fields.
+     * @param args running main with "parents" as args[0] tells AstPrintVisitor to print AstNodes with information about parent fields.
      * @throws Exception
      */
     public static void main(String[] args) throws Exception {
@@ -49,7 +49,7 @@ public class ParLang {
         //print AST
         System.out.println("AST:");
         AstPrintVisitor astPrintVisitor = new AstPrintVisitor();
-        astPrintVisitor.visit(0, ast, args[0]); //if args[0] is "1" then tree is printed with info about parent node of each AstNode.
+        astPrintVisitor.visit(0, ast, args[0]); //if args[0] is "parents" then tree is printed with info about parent node of each AstNode.
 
         //print CST
         System.out.println("CST:");

--- a/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
@@ -22,6 +22,11 @@ import org.abcd.examples.ParLang.AstNodes.AstNode;
 
 
 public class ParLang {
+    /***
+     *
+     * @param args running main with "1" as args[0] tells AstPrintVisitor to print AstNodes with information about parent fields.
+     * @throws Exception
+     */
     public static void main(String[] args) throws Exception {
         // create a CharStream that reads from standard input
         ANTLRInputStream input = new ANTLRInputStream(System.in);
@@ -44,7 +49,7 @@ public class ParLang {
         //print AST
         System.out.println("AST:");
         AstPrintVisitor astPrintVisitor = new AstPrintVisitor();
-        astPrintVisitor.visit(0, ast);
+        astPrintVisitor.visit(0, ast, args[0]); //if args[0] is "1" then tree is printed with info about parent node of each AstNode.
 
         //print CST
         System.out.println("CST:");

--- a/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/ParLang.java
@@ -49,7 +49,11 @@ public class ParLang {
         //print AST
         System.out.println("AST:");
         AstPrintVisitor astPrintVisitor = new AstPrintVisitor();
-        astPrintVisitor.visit(0, ast, args[0]); //if args[0] is "parents" then tree is printed with info about parent node of each AstNode.
+        String printOption="";
+        if(args.length>0){
+            printOption=args[0];
+        }
+        astPrintVisitor.visit(0, ast, printOption); //if printOption is "parents" then tree is printed with info about parent node of each AstNode.
 
         //print CST
         System.out.println("CST:");


### PR DESCRIPTION
-parent field added to AstNode class
-parent is set in the addChild method of the AstNode class (nodes are always added to the AST via addChild, so parent of each node can be set this way). 
-In order to test if parent field was set correctly for all nodes, I added functionality for printing ast with information of each node's parent . Here hashcodes are printed for each node in order to ensure that the parent field is set correct. 
-I fixed a problem i visitReturnStatement. If the return statement is "return;" the previous code visited the ";".