### PR TITLE
Added type to AstNode

### DIFF
--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AccessNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AccessNode.java
@@ -2,15 +2,11 @@ package org.abcd.examples.ParLang.AstNodes;
 import org.abcd.examples.ParLang.NodeVisitor;
 
 public abstract class AccessNode extends AstNode{
-    private String accessType;
     private String accessIdentifier;
     public AccessNode(String accessType, String accessValue){
-        this.accessType = accessType;
+        setType(accessType); //Type property is inherited from AstNode
         this.accessIdentifier = accessValue;
 
-    }
-    public String getAccessType() {
-        return accessType;
     }
 
     public String getAccessIdentifier() {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 public abstract class AstNode {
     private List<AstNode> children = new ArrayList<>();
     private AstNode parent;
+    private String type;
     public List<AstNode> getChildren() {
         return children;
     }
@@ -25,6 +26,13 @@ public abstract class AstNode {
 
     public AstNode getParent() {
         return parent;
+    }
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
     }
 
     //Generates a hash code based on the memory address of the object

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/IdentifierNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/IdentifierNode.java
@@ -5,24 +5,19 @@ import org.abcd.examples.ParLang.NodeVisitor;
 
 public class IdentifierNode extends AstNode{
     private final String name;
-    private final String type;
 
     public IdentifierNode(String name, String type){
         this.name=name;
-        this.type=type;
+        setType(type);
     }
 
     public IdentifierNode(String name){
         this.name=name;
-        this.type=null;
+        setType(null);
     }
 
     public String getName() {
         return name;
-    }
-
-    public String getType() {
-        return type;
     }
     @Override
     public void accept(NodeVisitor visitor) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ScriptMethodNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/ScriptMethodNode.java
@@ -1,19 +1,13 @@
 package org.abcd.examples.ParLang.AstNodes;
 
 public class ScriptMethodNode extends DclNode{
-
-    private final String returnType;
     private final String methodType;
 
     public ScriptMethodNode(String id, String returnType, String methodType) {
         super(id);
-        this.returnType=returnType;
+        setType(returnType);
         this.methodType=methodType;
     }
 
     public String getMethodType(){return  methodType;}
-
-    public String getReturnType() {
-        return returnType;
-    }
 }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnActorNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/SpawnActorNode.java
@@ -3,14 +3,9 @@ package org.abcd.examples.ParLang.AstNodes;
 import org.abcd.examples.ParLang.NodeVisitor;
 
 public class SpawnActorNode extends AstNode{
-    private final String ActorType;
 
     public SpawnActorNode(String ActorType){
-        this.ActorType=ActorType;
-    }
-
-    public String getActorType(){
-        return this.ActorType;
+        setType(ActorType);
     }
 
     @Override

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/VarDclNode.java
@@ -4,13 +4,9 @@ import org.abcd.examples.ParLang.LanguageType;
 import org.abcd.examples.ParLang.NodeVisitor;
 
 public class VarDclNode extends DclNode{
-    private final String type;
     public VarDclNode(String id, String type) {
         super(id);
-        this.type=type;
-    }
-    public String getType() {
-        return type;
+        setType(type);
     }
 
     @Override

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstPrintVisitor.java
@@ -52,7 +52,7 @@ public class AstPrintVisitor {
                     }
                     break;
                 case "SpawnActorNode":
-                    this.print(localIndent, className + " : " + ((SpawnActorNode)node).getActorType());
+                    this.print(localIndent, className + " : " + ((SpawnActorNode)node).getType());
                     break;
                 case "StringNode":
                     this.print(localIndent, className + " : " + ((StringNode)node).getValue());
@@ -61,13 +61,13 @@ public class AstPrintVisitor {
                     this.print(localIndent, className + " id: " + ((ActorDclNode)node).getId());
                     break;
                 case "MethodDclNode":
-                    this.print(localIndent, className + " " +((MethodDclNode)node).getMethodType()+ " id: " + ((MethodDclNode)node).getId()+ " return type: "+((MethodDclNode)node).getReturnType());
+                    this.print(localIndent, className + " " +((MethodDclNode)node).getMethodType()+ " id: " + ((MethodDclNode)node).getId()+ " return type: "+((MethodDclNode)node).getType());
                     break;
                 case "ScriptMethodNode":
                     if (((ScriptMethodNode)node).getMethodType().equals("on")) {
                         this.print(localIndent, className + " " + ((ScriptMethodNode) node).getMethodType() + " with id: " + ((ScriptMethodNode) node).getId());
                     }else{
-                        this.print(localIndent, className + " " + ((ScriptMethodNode) node).getMethodType() + " with id: " + ((ScriptMethodNode) node).getId() + " return type: " + ((ScriptMethodNode) node).getReturnType());
+                        this.print(localIndent, className + " " + ((ScriptMethodNode) node).getMethodType() + " with id: " + ((ScriptMethodNode) node).getId() + " return type: " + ((ScriptMethodNode) node).getType());
                     }
                     break;
                 case "ScriptDclNode":
@@ -80,16 +80,16 @@ public class AstPrintVisitor {
                     this.print(localIndent, className);
                     break;
                 case "ArrayAccessNode":
-                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getAccessType() );
+                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getType() );
                     break;
                 case "ActorAccessNode":
-                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getAccessType() );
+                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getType() );
                     break;
                 case "StateAccessNode":
-                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getAccessType() );
+                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getType() );
                     break;
                 case "KnowsAccessNode":
-                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getAccessType() );
+                    this.print( localIndent, className + " access id " + ((AccessNode)node).getAccessIdentifier() + " of type: " + ((AccessNode)node).getType() );
                     break;
                 case "ArgumentsNode":
                     if (((ArgumentsNode)node).getChildren().size() > 0){


### PR DESCRIPTION
 Allows getType() on any AstNode
Useful when traversing AST an need to getType() of children, but children can consist of multiple different nodes