### PR TITLE
Fixed multiple problems with TypeChecking

### DIFF
--- a/generator/input/EmilKodeGiverFejl.par
+++ b/generator/input/EmilKodeGiverFejl.par
@@ -1,8 +1,4 @@
-Script number{
-    local squared(double num): double;
-}
-
-Actor numActor follows number{
+Actor numActor{
     State{
         double number;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
@@ -1,9 +1,9 @@
 package org.abcd.examples.ParLang;
 
 import org.abcd.examples.ParLang.AstNodes.*;
+import org.abcd.examples.ParLang.symbols.Attributes;
 import org.abcd.examples.ParLang.symbols.SymbolTable;
-
-import java.util.ArrayList;
+import java.util.HashMap;
 
 public class MethodCallVisitor implements NodeVisitor {
     SymbolTable symbolTable;
@@ -14,8 +14,8 @@ public class MethodCallVisitor implements NodeVisitor {
 
     @Override
     public void visit(MethodCallNode node) {
-        ArrayList<String> legalMethods = this.symbolTable.getDeclaredLocalMethods();
-        if (legalMethods.contains(node.getMethodName())) {
+        HashMap<String, Attributes> legalMethods = this.symbolTable.getDeclaredLocalMethods();
+        if (legalMethods.containsKey(node.getMethodName())) {
             System.out.println("Local method id " + node.getMethodName() + " found");
         }
         else {
@@ -114,11 +114,6 @@ public class MethodCallVisitor implements NodeVisitor {
     public void visit(ArgumentsNode node) {
         this.visitChildren(node);
     }
-
-    /*@Override
-    public void visit(DclNode node) {
-        this.visitChildren(node);
-    }*/
 
     @Override
     public void visit(VarDclNode node) {

--- a/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
@@ -92,7 +92,8 @@ public class SymbolTableVisitor implements NodeVisitor {
     //Creates the scope for the method node and leaves it after visiting the children
     public void visit(MethodDclNode node){
         if(Objects.equals(node.getMethodType(), "local")){
-            this.symbolTable.insertLocalMethod(node.getId());
+            Attributes attributes = new Attributes(node.getType(), "local");
+            this.symbolTable.insertLocalMethod(node.getId(), attributes);
         }
         if(this.symbolTable.addScope(node.getId())){
             //Visits the children of the node to add the symbols to the symbol table

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -76,6 +76,8 @@ public class TypeVisitor implements NodeVisitor {
         /*try {*/
             if (symbolTable.lookUpSymbol(node.getMsgName()) == null) {
                 throw new MethodCallException("Method: " + node.getMsgName() + " not found");
+            }else {
+                System.out.println("Method: " + node.getMsgName() + " found");
             }
             symbolTable.enterScope(node.getMsgName());
             this.visitChildren(node);
@@ -103,13 +105,14 @@ public class TypeVisitor implements NodeVisitor {
 
     @Override
     public void visit(IdentifierNode node) {
+        System.out.println("Symbol: " + node.getName());
         /*try {*/
             if (hasParent(node, StateNode.class)) {
                 node.setType(this.symbolTable.lookUpStateSymbol(node.getName()).getVariableType());
             } else if (hasParent(node, KnowsNode.class)) {
                 node.setType(this.symbolTable.lookUpKnowsSymbol(node.getName()).getVariableType());
             } else {
-                node.setType(this.symbolTable.lookUpSymbolCurrentScope(node.getName()).getVariableType());
+                node.setType(this.symbolTable.lookUpSymbol(node.getName()).getVariableType());
             }
         /*}
         catch (Exception e) {
@@ -168,6 +171,8 @@ public class TypeVisitor implements NodeVisitor {
         /*try {*/
             if (symbolTable.lookUpSymbol(node.getMethodName()) == null) {
                 throw new MethodCallException("Method: " + node.getMethodName() + " not found");
+            } else{
+                System.out.println("Method: " + node.getMethodName() + " found");;
             }
             symbolTable.enterScope(node.getMethodName());
             this.visitChildren(node);
@@ -645,9 +650,11 @@ public class TypeVisitor implements NodeVisitor {
             Attributes attributes;
             if (hasParent(node, StateAccessNode.class)){
                 attributes = symbolTable.lookUpStateSymbol(id);
+                System.out.println("Symbol: " + node.getAccessIdentifier());
             }
             else{
                 attributes = symbolTable.lookUpSymbol(id);
+                System.out.println("Symbol: " + node.getAccessIdentifier());
             }
             if (attributes == null){
                 throw new ArrayAccessException("Array: " + id + " not found");
@@ -668,15 +675,18 @@ public class TypeVisitor implements NodeVisitor {
             if (!hasParent(node, ActorDclNode.class)){
                 throw new StateAccessException("StateAccessNode is not a child of ActorDclNode");
             }
-            if (node.getChildren().size() > 0){
+            if (!node.getChildren().isEmpty()){
                 this.visitChildren(node);
                 node.setType(node.getChildren().get(0).getType());
             }
             else {
                 String id = node.getAccessIdentifier();
+                System.out.println("StateAccess: Symbol: " + id);
                 Attributes attributes = symbolTable.lookUpStateSymbol(id);
                 if (attributes == null) {
                     throw new StateAccessException("State: " + id + " not found");
+                }else{
+                    System.out.println("Symbol: " + node.getAccessIdentifier());
                 }
                 node.setType(attributes.getVariableType());
             }

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -534,9 +534,9 @@ public class TypeVisitor implements NodeVisitor {
         if (leftType.equals("int") && rightType.equals("int"))
         {
             return "int";
-        }
-        if (leftType.equals("int") && rightType.equals("double") ||
-            leftType.equals("double") && rightType.equals("int")){
+        } else if ( leftType.equals("int") && rightType.equals("double") ||
+                    leftType.equals("double") && rightType.equals("int") ||
+                    leftType.equals("double") && rightType.equals("double")){
             return "double";
         }
         //All other cases returns null(Also where left or right type == null)

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -1,11 +1,9 @@
 package org.abcd.examples.ParLang;
 
-import com.sun.source.tree.LiteralTree;
 import org.abcd.examples.ParLang.AstNodes.*;
 import org.abcd.examples.ParLang.Exceptions.*;
 import org.abcd.examples.ParLang.symbols.Attributes;
 import org.abcd.examples.ParLang.symbols.SymbolTable;
-import org.abcd.examples.ParLang.symbols.Scope;
 
 import java.util.*;
 
@@ -167,10 +165,11 @@ public class TypeVisitor implements NodeVisitor {
     @Override
     public void visit(MethodCallNode node) {
         /*try {*/
-            if (!symbolTable.getDeclaredLocalMethods().contains(node.getMethodName())) {
+            if (!symbolTable.getDeclaredLocalMethods().containsKey(node.getMethodName())) {
                 throw new MethodCallException("Method: " + node.getMethodName() + " not found");
             } else{
-                System.out.println("Method: " + node.getMethodName() + " found");;
+                System.out.println("Method: " + node.getMethodName() + " found");
+                node.setType(symbolTable.getDeclaredLocalMethods().get(node.getMethodName()).getVariableType());
             }
             symbolTable.enterScope(node.getMethodName());
             this.visitChildren(node);
@@ -381,7 +380,7 @@ public class TypeVisitor implements NodeVisitor {
             this.symbolTable.enterScope(node.getId());
             this.visitChildren(node);
             String childType = node.getChildren().get(1).getType();
-            if (!node.getType().equals(childType)) {
+            if (!node.getType().equals(childType) && node.getMethodType().equals("local")) {
                 throw new MethodDclNodeException("Return does not match returnType of method");
             }
             this.symbolTable.leaveScope();

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -112,6 +112,7 @@ public class TypeVisitor implements NodeVisitor {
             } else if (hasParent(node, KnowsNode.class)) {
                 node.setType(this.symbolTable.lookUpKnowsSymbol(node.getName()).getVariableType());
             } else {
+                System.out.println("Normal Symbol: " + node.getName());
                 node.setType(this.symbolTable.lookUpSymbol(node.getName()).getVariableType());
             }
         /*}

--- a/generator/src/main/java/org/abcd/examples/ParLang/symbols/Scope.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/symbols/Scope.java
@@ -8,7 +8,7 @@ public class Scope {
 
     //The symbols in the scope
     private final HashMap<String, Attributes> symbols = new HashMap<>();
-    private final Map<String, Attributes> params = new LinkedHashMap<>();
+    private final LinkedHashMap<String, Attributes> params = new LinkedHashMap<>();
     private final HashMap<String, Attributes> stateSymbols = new HashMap<>();
     private final HashMap<String, Attributes> knowsSymbols = new HashMap<>();
     private final ArrayList<String> declaredLocalMethods = new ArrayList<>();
@@ -45,7 +45,7 @@ public class Scope {
         this.params.put(id, attributes);
     }
 
-    public Map<String, Attributes> getParams() {
+    public LinkedHashMap<String, Attributes> getParams() {
         return this.params;
     }
 
@@ -53,7 +53,7 @@ public class Scope {
         this.stateSymbols.put(id, attributes);
     }
 
-    public Map<String, Attributes> getStateSymbols() {
+    public HashMap<String, Attributes> getStateSymbols() {
         return this.stateSymbols;
     }
 
@@ -61,7 +61,7 @@ public class Scope {
         this.knowsSymbols.put(id, attributes);
     }
 
-    public Map<String, Attributes> getKnowsSymbols() {
+    public HashMap<String, Attributes> getKnowsSymbols() {
         return this.knowsSymbols;
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/symbols/Scope.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/symbols/Scope.java
@@ -11,7 +11,7 @@ public class Scope {
     private final LinkedHashMap<String, Attributes> params = new LinkedHashMap<>();
     private final HashMap<String, Attributes> stateSymbols = new HashMap<>();
     private final HashMap<String, Attributes> knowsSymbols = new HashMap<>();
-    private final ArrayList<String> declaredLocalMethods = new ArrayList<>();
+    private final HashMap<String, Attributes> declaredLocalMethods = new HashMap<>();
 
 
     //Nested scopes within the current scope
@@ -65,22 +65,22 @@ public class Scope {
         return this.knowsSymbols;
     }
 
-    public void addDeclaredLocalMethod(String id) {
-        if(!this.declaredLocalMethods.contains(id)){
-            this.declaredLocalMethods.add(id);
+    public void addDeclaredLocalMethod(String id, Attributes attributes) {
+        if(!this.declaredLocalMethods.containsKey(id)){
+            this.declaredLocalMethods.put(id, attributes);
         }else{
             System.out.println("Duplicate method id: " + id);
         }
     }
 
-    public ArrayList<String> getDeclaredLocalMethods() {
+    public HashMap<String, Attributes> getDeclaredLocalMethods() {
         if(!this.declaredLocalMethods.isEmpty()){
             return this.declaredLocalMethods;
         }else{
             if(this.parent != null){
                 return this.parent.getDeclaredLocalMethods();
             }else{
-                return new ArrayList<>();
+                return new HashMap<>();
             }
         }
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/symbols/SymbolTable.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/symbols/SymbolTable.java
@@ -1,6 +1,7 @@
 package org.abcd.examples.ParLang.symbols;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Stack;
 
 public class SymbolTable {
@@ -161,11 +162,11 @@ public class SymbolTable {
 
     public void insertKnowsSymbol(String symbol, Attributes attributes){this.currentScope.addKnowsSymbols(symbol, attributes);}
 
-    public void insertLocalMethod(String symbol){
-        this.currentScope.addDeclaredLocalMethod(symbol);
+    public void insertLocalMethod(String symbol, Attributes attributes){
+        this.currentScope.addDeclaredLocalMethod(symbol, attributes);
     }
 
-    public ArrayList<String> getDeclaredLocalMethods(){
+    public HashMap<String, Attributes> getDeclaredLocalMethods(){
         return this.currentScope.getDeclaredLocalMethods();
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/symbols/SymbolTable.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/symbols/SymbolTable.java
@@ -123,6 +123,7 @@ public class SymbolTable {
         //Returns the symbol if it is found or returns null if the symbol is not found
         while(scope != null){
             if(!scope.getStateSymbols().isEmpty() && scope.getStateSymbols().containsKey(symbol)){
+                System.out.println("Symbol: " + symbol + " found");
                 return scope.getStateSymbols().get(symbol);
             }
 


### PR DESCRIPTION
visit(IdentifierNode) now checks whether it is an identifierNode with a parent of type MethodCallNode, since these are not entered into the symbolTable.
Removed enterScope and leaveScope from visit(ParametersNode).
In visit(MethodCallNode) it does not lookUpSymbol, it instead gets Declared Local Methods and whether it contains the method call.
CheckArgTypes now iterates through the passed params using innate method .entrySet().iterator().next() from LinkedHashMap.
Params LinkedHashMap is no longer cast to a Map.
Changed declaredLocalMethods to HashMap in Scope.java. As well as changes needed because of it.
This is done so that the return type of the method can be accessed through the symbolTable.
Type is now set on MethodCallNode in TypeVisitor.java.
It is now checked whether the method is an on method or local method, when checking for return type match on MethodDclNode, as on methods does not have a return type.
Added check for double && double types in findResultingType.