### PR TITLE
Visiting Arguments in TypeVisitor

### DIFF
--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
@@ -44,7 +44,7 @@ public class MethodCallVisitor implements NodeVisitor {
 
     @Override
     public void visit(ScriptDclNode node) {
-        this.symbolTable.enterScope(node.getNodeHash());
+        this.symbolTable.enterScope(node.getId());
         this.visitChildren(node);
         this.symbolTable.leaveScope();
     }
@@ -80,7 +80,7 @@ public class MethodCallVisitor implements NodeVisitor {
 
     @Override
     public void visit(ActorDclNode node) {
-        this.symbolTable.enterScope(node.getNodeHash());
+        this.symbolTable.enterScope(node.getId());
         this.visitChildren(node);
         this.symbolTable.leaveScope();
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
@@ -32,7 +32,7 @@ public class SymbolTableVisitor implements NodeVisitor {
 
     @Override
     public void visit(ScriptDclNode node) {
-        this.symbolTable.addScope(node.getNodeHash());
+        this.symbolTable.addScope(node.getId());
         //Visits the children of the node to add the symbols to the symbol table
         this.visitChildren(node);
         //Leaves the scope after visiting the children, as the variables in the Script node are not available outside the Script node
@@ -121,7 +121,7 @@ public class SymbolTableVisitor implements NodeVisitor {
 
     @Override
     public void visit(ActorDclNode node) {
-        this.symbolTable.addScope(node.getNodeHash());
+        this.symbolTable.addScope(node.getId());
         //Visits the children of the node to add the symbols to the symbol table
         this.visitChildren(node);
         //Leaves the scope after visiting the children, as the variables in the Actor node are not available outside the Actor node

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -71,7 +71,7 @@ public class TypeVisitor implements NodeVisitor {
     @Override
     public void visit(SendMsgNode node) {
         /*try {*/
-            if (symbolTable.lookUpSymbol(node.getMsgName()) == null) {
+            if (symbolTable.lookUpScope(node.getMsgName()) == null) {
                 throw new MethodCallException("Method: " + node.getMsgName() + " not found");
             }else {
                 System.out.println("Method: " + node.getMsgName() + " found");

--- a/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/TypeVisitor.java
@@ -3,7 +3,9 @@ package org.abcd.examples.ParLang;
 import org.abcd.examples.ParLang.AstNodes.*;
 import org.abcd.examples.ParLang.Exceptions.*;
 import org.abcd.examples.ParLang.symbols.Attributes;
+import org.abcd.examples.ParLang.symbols.Scope;
 import org.abcd.examples.ParLang.symbols.SymbolTable;
+
 
 import java.util.*;
 
@@ -31,7 +33,7 @@ public class TypeVisitor implements NodeVisitor {
     @Override
     public void visit(ScriptDclNode node) {
         /*try {*/
-            this.symbolTable.enterScope(node.getNodeHash());
+            this.symbolTable.enterScope(node.getId());
             this.visitChildren(node);
             if (node.getId() == null) {
                 throw new ScriptDclException("Type is not defined for script declaration node");
@@ -204,18 +206,27 @@ public class TypeVisitor implements NodeVisitor {
     public void visit(ArgumentsNode node) {
         this.visitChildren(node);
         /*try {*/
-            LinkedHashMap<String, Attributes> params = symbolTable.getCurrentScope().getParams();
+            LinkedHashMap<String, Attributes> params;
             AstNode parent = node.getParent();
             int numOfChildren = node.getChildren().size();
             if (parent instanceof MethodCallNode) {
+                params = symbolTable.getCurrentScope().getParams();
                 MethodCallNode methodCallNode = (MethodCallNode) parent;
                 String methodName = methodCallNode.getMethodName();
                 checkArgTypes(node, params, methodName);
             } else if (parent instanceof SpawnActorNode) {
+                //We can call SpawnActor from any scope, hence we have to find the Actor scope where the Spawn we are calling is declared
+                Scope ActorScope = symbolTable.lookUpScope(parent.getType());
+                //Within the Actor Scope we enter the spawn scope to get the parameters associated with Spawn
+                Scope SpawnScope = ActorScope.children.get(0);
+                params = SpawnScope.getParams();
                 SpawnActorNode spawnActorNode = (SpawnActorNode) parent;
                 String actorName = spawnActorNode.getType();
                 checkArgTypes(node, params, actorName);
             } else if (parent instanceof SendMsgNode) {
+                //TODO Lookup correct scope for onMethod calls
+                Scope ActorScope = symbolTable.lookUpScope(parent.getType());
+                params = ActorScope.getParams();
                 SendMsgNode sendMsgNode = (SendMsgNode) parent;
                 String msgName = sendMsgNode.getMsgName();
                 checkArgTypes(node, params, msgName);
@@ -334,7 +345,7 @@ public class TypeVisitor implements NodeVisitor {
     @Override
     public void visit(ActorDclNode node) {
         /*try {*/
-            this.symbolTable.enterScope(node.getNodeHash());
+            this.symbolTable.enterScope(node.getId());
             this.visitChildren(node);
             this.symbolTable.leaveScope();
         /*}


### PR DESCRIPTION
**Entering Scope:**
- We now enter scope of Actors and Script based on their Id and not their HashCode

**Visiting arguments in the type checker:**
- Since a Spawn method call can happen in any actor, we need a way find a way to check the type of the arguments against the parameters defined in the Spawn decleration of the actor associated to the Spawn call
- Arguments in the Spawn call ex: Spawn ActorType(arg1, arg2) are contained within a SpawnActorNode, which contains the type of the actor we are trying to spawn
- We find the scope of this actor
- Since the parameters are not defined within the ActorScope, but in the scope of the Spawn declaration, we find the first child of the ActorScope, which must be the Spawn scope
- These are then matched against the actual arguments, with code which was already working