### PR TITLE
MethodVisitor can now handle when receiver is StateAcces, KnowsAcess or self

### DIFF
--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -59,8 +59,14 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitSendMsg(ParLangParser.SendMsgContext ctx) {
         //SendMsg has the structure: [IDENTIFIER,SEND_MSG,IDENTIFIER,LPAREN,ARGUMENTS,RPAREN]
-        SendMsgNode sendMsgNode = new SendMsgNode(ctx.getChild(0).getText(), ctx.getChild(2).getText());
-        sendMsgNode.addChild(visit(ctx.identifier(0))); //Add the receiver as a Knows child
+        String receiver = ctx.getChild(0).getText();
+        String msgName = ctx.getChild(2).getText();
+        SendMsgNode sendMsgNode = new SendMsgNode(receiver, msgName);
+        if(receiver.equals("self")){
+            sendMsgNode.addChild(new SelfNode());
+        }else{
+            sendMsgNode.addChild(visit(ctx.identifier(0))); //Add the receiver as a Knows or State child
+        }
         sendMsgNode.addChild(visit(ctx.arguments())); //add arguments as children
         return sendMsgNode;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -60,6 +60,7 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitSendMsg(ParLangParser.SendMsgContext ctx) {
         //SendMsg has the structure: [IDENTIFIER,SEND_MSG,IDENTIFIER,LPAREN,ARGUMENTS,RPAREN]
         SendMsgNode sendMsgNode = new SendMsgNode(ctx.getChild(0).getText(), ctx.getChild(2).getText());
+        sendMsgNode.addChild(visit(ctx.identifier(0))); //Add the receiver as a Knows child
         sendMsgNode.addChild(visit(ctx.arguments())); //add arguments as children
         return sendMsgNode;
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
@@ -28,7 +28,11 @@ public class MethodCallVisitor implements NodeVisitor {
     @Override
     public void visit(SendMsgNode node) {
         //First we enter the scope of the Actor we send the message to
-        this.symbolTable.enterScope(this.symbolTable.lookUpSymbol(node.getReceiver()).getVariableType());
+        if(node.getReceiver().equals("self")){ //You can also send messages to yourself
+            this.symbolTable.enterScope(this.symbolTable.getCurrentScope().getScopeName());
+        }else{ //In other cases it should be another onMethod in an actor
+            this.symbolTable.enterScope(this.symbolTable.lookUpSymbol(node.getReceiver()).getVariableType());
+        }
 
         //Then we find the list of messages it can receive
         HashMap<String, Attributes> legalOnMethods = this.symbolTable.getDeclaredOnMethods();

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodCallVisitor.java
@@ -29,7 +29,7 @@ public class MethodCallVisitor implements NodeVisitor {
     public void visit(SendMsgNode node) {
         //First we enter the scope of the Actor we send the message to
         if(node.getReceiver().equals("self")){ //You can also send messages to yourself
-            this.symbolTable.enterScope(this.symbolTable.getCurrentScope().getScopeName());
+            this.symbolTable.enterScope(this.symbolTable.findActorParent(node));
         }else{ //In other cases it should be another onMethod in an actor
             this.symbolTable.enterScope(this.symbolTable.lookUpSymbol(node.getReceiver()).getVariableType());
         }


### PR DESCRIPTION
Added:
- SendMsgNode can now have SelfNode, StateAccessNode or KnowsAccessNode as the first child
- SendMsgCalls access correct scope based on the type of the receiver