### PR TITLE
Added lineNumber and columnNumber to all nodes in the AST

### DIFF
--- a/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstNodes/AstNode.java
@@ -11,6 +11,9 @@ public abstract class AstNode {
     private List<AstNode> children = new ArrayList<>();
     private AstNode parent;
     private String type;
+    int lineNumber;
+    int columnNumber;
+
     public List<AstNode> getChildren() {
         return children;
     }
@@ -34,6 +37,22 @@ public abstract class AstNode {
     public void setType(String type) {
         this.type = type;
     }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+
+    public void setColumnNumber(int columnNumber) {
+        this.columnNumber = columnNumber;
+    }
+
 
     //Generates a hash code based on the memory address of the object
     //Not guaranteed to be unique, but probability of identical hashcode is low

--- a/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/AstVisitor.java
@@ -18,6 +18,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitInit(ParLangParser.InitContext ctx) {
         //Init is the root of the AST
         InitNode initNode=new InitNode();
+        initNode.setLineNumber(ctx.getStart().getLine());
+        initNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         //visit all children of the init node, which can be MainFunc, Actor, or Script
         return childVisitor(initNode,ctx.children);
     }
@@ -36,6 +38,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitMainFunc(ParLangParser.MainFuncContext ctx) {
         //Main function is the entry point of the program
         MainDclNode main= new MainDclNode(ctx.MAIN().getText());
+        main.setLineNumber(ctx.getStart().getLine());
+        main.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(!ctx.parameters().getText().equals("()")){ //If there are parameters
             main.addChild(visit(ctx.parameters())); //add parameters as children to the main node
         }
@@ -47,6 +52,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitMethodCall(ParLangParser.MethodCallContext ctx) {
         MethodCallNode methodCallNode = new MethodCallNode(ctx.identifier().getText());
+        methodCallNode.setLineNumber(ctx.getStart().getLine());
+        methodCallNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(ctx.arguments()!=null){ //If there are arguments
             //visit the arguments and add them as children to the methodCallNode
             return childVisitor(methodCallNode,ctx.children);
@@ -59,8 +67,14 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         String receiver = ctx.getChild(0).getText();
         String msgName = ctx.getChild(2).getText();
         SendMsgNode sendMsgNode = new SendMsgNode(receiver, msgName);
+        sendMsgNode.setLineNumber(ctx.getStart().getLine());
+        sendMsgNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(receiver.equals(parLangE.SELF.getValue())){
-            sendMsgNode.addChild(new SelfNode());
+            SelfNode selfNode = new SelfNode();
+            selfNode.setLineNumber(ctx.getStart().getLine());
+            selfNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            sendMsgNode.addChild(selfNode);
         } else{
             sendMsgNode.addChild(visit(ctx.identifier(0))); //Add the receiver as a Knows or State child
         }
@@ -71,16 +85,25 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitParameters(ParLangParser.ParametersContext ctx){
         int numOfChildren=ctx.getChildCount();
         ParametersNode params = new ParametersNode();
+        params.setLineNumber(ctx.getStart().getLine());
+        params.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if (numOfChildren != 2){ //there are minimum 2 children, the parentheses
             //If there are more than 2 children, there are parameters
             for (int i = 1; i < numOfChildren; i+=3){ //skip the commas
-                params.addChild(new IdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText()));
+                IdentifierNode identifierNode = new IdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText());
+                identifierNode.setLineNumber(ctx.getStart().getLine());
+                identifierNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+                params.addChild(identifierNode);
             } //add the parameters as children to the parametersNode
         }
         return params; //return the parametersNode with all parameters added as children
     }
     @Override public AstNode visitArguments(ParLangParser.ArgumentsContext ctx){
         ArgumentsNode args = new ArgumentsNode();
+        args.setLineNumber(ctx.getStart().getLine());
+        args.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         //visit all children of the arguments node and add them as children to the argumentsNode
         return childVisitor(args,ctx.children); //return the argumentsNode with all arguments added as children
     }
@@ -89,6 +112,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         try {
             String scriptName = ctx.identifier().getText();
             ScriptDclNode node = new ScriptDclNode(scriptName);
+            node.setLineNumber(ctx.getStart().getLine());
+            node.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
             if (typeContainer.hasType(scriptName)) {//if another actor is declared with the same name we may have conflicting types.
                 throw new DuplicateScriptTypeException("Actor with name " + scriptName + " already defined");
             } else {//extend the typeContainer list with new types
@@ -120,6 +146,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 returnType = null;
         }
         ScriptMethodNode node = new ScriptMethodNode(ctx.identifier().getText(), returnType, methodType);
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(!ctx.parameters().getText().equals("()")){ //If there are parameters
             node.addChild(visit(ctx.parameters())); //add parameters as children
         }
@@ -136,6 +165,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
                 typeContainer.addType(actorName); //add the actorType to the typeContainer
             }
             ActorDclNode node = new ActorDclNode(ctx.identifier().getText());
+            node.setLineNumber(ctx.getStart().getLine());
+            node.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
             List<ParseTree> children = new ArrayList<ParseTree>(ctx.children);
             children.remove(1);//remove identifier from list of children
             //visit all children of the actor node and add them as children to the actorNode
@@ -151,6 +183,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitFollow(ParLangParser.FollowContext ctx) {
         FollowsNode followNode = new FollowsNode();
+        followNode.setLineNumber(ctx.getStart().getLine());
+        followNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         List<ParseTree> children = new ArrayList<ParseTree>(ctx.children);
         children.remove(0);//remove "follows" from list of children
         return childVisitor(followNode,children); //visit all children of the follow node and add them as children to the followNode
@@ -158,6 +193,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitActorState(ParLangParser.ActorStateContext ctx) {
         StateNode node= new StateNode(ctx.STATE().getText());
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         //visit all children of the actorState node and add them as children to the actorStateNode
         return childVisitor(node,ctx.children);
     }
@@ -165,10 +203,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override public AstNode visitActorKnows(ParLangParser.ActorKnowsContext ctx) {
         int numOfChildren=ctx.getChildCount();
         KnowsNode knowsNode= new KnowsNode(ctx.KNOWS().getText());
+        knowsNode.setLineNumber(ctx.getStart().getLine());
+        knowsNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if (numOfChildren != 3){ //there are minimum 3 children, the parentheses and "knows" token
             //If there are more than 3 children, there are known actors
             for (int i = 2; i < numOfChildren-1; i+=3){ //skip the semicolons
-                knowsNode.addChild(new IdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText()));
+                IdentifierNode identifierNode = new IdentifierNode(ctx.getChild(i+1).getText(), ctx.getChild(i).getText());
+                identifierNode.setLineNumber(ctx.getStart().getLine());
+                identifierNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+                knowsNode.addChild(identifierNode);
             } //add the known actors as children to the knowsNode
         }
         return knowsNode; //return the knowsNode with all known actors added as children
@@ -176,6 +220,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitSpawn(ParLangParser.SpawnContext ctx) {
         SpawnDclNode node= new SpawnDclNode();
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(!ctx.parameters().getText().equals("()")){//If there are parameters
             node.addChild(visit(ctx.parameters())); //visit and add parameters as children to the spawnNode
         }
@@ -187,6 +234,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitSpawnActor(ParLangParser.SpawnActorContext ctx) {
         SpawnActorNode spawnNode = new SpawnActorNode(ctx.identifier().getText());
+        spawnNode.setLineNumber(ctx.getStart().getLine());
+        spawnNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(ctx.arguments() != null){//If there are arguments
             spawnNode.addChild(visit(ctx.arguments())); //visit and add arguments as children to the spawnNode
         }
@@ -198,11 +248,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         //Need to know: Identifier of what we want to access and the type of the value the identifier points to
         String accessType = "EMPTY"; //Until type-checker is implemented
         if (ctx.IDENTIFIER() != null) { //If the access is a simple identifier
-            return new StateAccessNode(accessType, ctx.IDENTIFIER().getText()); //return a StateAccessNode with the accessType and accessIdentifier
+            StateAccessNode stateAccessNode = new StateAccessNode(accessType, ctx.IDENTIFIER().getText());
+            stateAccessNode.setLineNumber(ctx.getStart().getLine());
+            stateAccessNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            return stateAccessNode; //return a StateAccessNode with the accessType and accessIdentifier
         } //If the access is an array access
 
         AstNode child = visit(ctx.getChild(2)); //visit the array access
         StateAccessNode node = new StateAccessNode(accessType, ((ArrayAccessNode)child).getAccessIdentifier());
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
         node.addChild(child); //add the array access as a child
         return node;
     }
@@ -211,11 +266,16 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         //We can access Knows within an Actor; Structure:[KNOWS,DOT,IDENTIFIER];
         String accessIdentifier = ctx.IDENTIFIER().getText();
         String accessType = "EMPTY"; //Until type-checker is implemented
-        return new KnowsAccessNode(accessType,accessIdentifier);//return a KnowsAccessNode with the accessIdentifier and accessType
+        KnowsAccessNode knowsAccessNode = new KnowsAccessNode(accessType,accessIdentifier);
+        knowsAccessNode.setLineNumber(ctx.getStart().getLine());
+        knowsAccessNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+        return knowsAccessNode;//return a KnowsAccessNode with the accessIdentifier and accessType
     }
 
     @Override public AstNode visitOnMethod(ParLangParser.OnMethodContext ctx) {
         MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),parLangE.VOID.getValue(), ctx.ON_METHOD().getText());
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
         if (ctx.parameters() != null) {//If there are parameters
             node.addChild(visit(ctx.parameters())); //visit and add parameters as children to the methodNode
         }
@@ -227,6 +287,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitLocalMethod(ParLangParser.LocalMethodContext ctx) {
         MethodDclNode node= new MethodDclNode(ctx.identifier().getText(),ctx.allTypes().getText(),ctx.LOCAL_METHOD().getText());
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
         if (ctx.parameters() != null) { //If there are parameters
             node.addChild(visit(ctx.parameters())); //visit and add parameters as children to the methodNode
         }
@@ -238,12 +300,17 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitBody(ParLangParser.BodyContext ctx) {
         BodyNode bodyNode =new BodyNode();
+        bodyNode.setLineNumber(ctx.getStart().getLine());
+        bodyNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         return childVisitor(bodyNode,ctx.children); //visit all children of the body node and add them as children to the bodyNode
     }
 
     @Override public AstNode visitPrintCall(ParLangParser.PrintCallContext ctx) {
         //PrintCall has the structure: [PRINT,LPAREN,PRINT_BODY,RPAREN]
         PrintCallNode printCallNode = new PrintCallNode();
+        printCallNode.setLineNumber(ctx.getStart().getLine());
+        printCallNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(ctx.printBody()!=null){ //If there is a printBody
             printCallHelper(printCallNode,ctx.printBody()); //visit the printBody and add it as a child to the printCallNode
         }
@@ -255,7 +322,10 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         int childCount=ctx.getChildCount();
         for (int i = 0; i < childCount; i+=2){
             if (ctx.getChild(i).getText().contains("\"")) {
-                parent.addChild(new StringNode(ctx.getChild(i).getText()));
+                StringNode stringNode = new StringNode(ctx.getChild(i).getText());
+                stringNode.setLineNumber(ctx.getStart().getLine());
+                stringNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+                parent.addChild(stringNode);
             } else {
                 parent.addChild(visit(ctx.getChild(i)));
             }
@@ -267,12 +337,20 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     public AstNode visitDeclaration(ParLangParser.DeclarationContext ctx) {
         String type = getTypeFromDclTypes(ctx.dclTypes());
         VarDclNode dclNode=new VarDclNode(ctx.identifier().getText(),type); //ctx.allTypes().getText() is e.g. "int[]" if int[] a={2,2} is visited
+        dclNode.setLineNumber(ctx.getStart().getLine());
+        dclNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         IdentifierNode idNode=new IdentifierNode(ctx.identifier().getText(),type);//ctx.allTypes().getText() is e.g. "int[]" if int[] a={2,2} is visited
+        idNode.setLineNumber(ctx.getStart().getLine());
+        idNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         dclNode.addChild(idNode); //add identifier as child
         ParLangParser.InitializationContext init=ctx.initialization(); //get the initialization value
         if(init!=null){//variable is initialized
             dclNode.setInitialized(true); //set the variable as initialized
             InitializationNode initializationNode=new InitializationNode();
+            initializationNode.setLineNumber(ctx.getStart().getLine());
+            initializationNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
             initializationNode.addChild(visit(init.getChild(1)));//child with index 1 is the initialization value (value can also be a list).
             dclNode.addChild(initializationNode); //add initializationNode as child
         }
@@ -306,12 +384,17 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override
     public AstNode visitList(ParLangParser.ListContext ctx){
-        return childVisitor(new ListNode(),ctx.children);//return a listNode with the list elements as children.
+        ListNode listNode = new ListNode();
+        listNode.setLineNumber(ctx.getStart().getLine());
+        listNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+        return childVisitor(listNode,ctx.children);//return a listNode with the list elements as children.
     }
 
     @Override
     public AstNode visitAssignment(ParLangParser.AssignmentContext ctx) {
         AssignNode assignNode = new AssignNode();
+        assignNode.setLineNumber(ctx.getStart().getLine());
+        assignNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
 
         AstNode varNode=visit(ctx.getChild(0)); //visit the variable
         AstNode valueNode=visit(ctx.getChild(2)); //visit the value
@@ -327,6 +410,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         AstNode IdNode = null; //initialize the IdNode
         if(ctx.IDENTIFIER() != null){ //If the identifier is a simple identifier
             IdNode = new IdentifierNode(ctx.IDENTIFIER().getText());
+            IdNode.setLineNumber(ctx.getStart().getLine());
+            IdNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         }
         if(ctx.actorAccess() != null){ //If the identifier is an actorAccess
             IdNode = visit(ctx.actorAccess());
@@ -361,7 +446,10 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         }else { //If there are no more operators
             rightChild=visit(parent.term(termIndex+1)); //visit the right child (term)
         }
-        return new ArithExpNode(operator,leftChild,rightChild); //return a new ArithExprNode with operator, leftChild, and rightChild
+        ArithExpNode arithExpNode = new ArithExpNode(operator,leftChild,rightChild);
+        arithExpNode.setLineNumber(parent.getStart().getLine());
+        arithExpNode.setColumnNumber(parent.getStart().getCharPositionInLine());
+        return arithExpNode; //return a new ArithExpNode with operator, leftChild, and rightChild
     }
 
     @Override public AstNode visitTerm(ParLangParser.TermContext ctx) {
@@ -387,7 +475,10 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         }else { //If there are no more operators
             rightChild=visit(parent.factor(factorIndex+1)); //add right child (factor)
         }
-        return new ArithExpNode(operator,leftChild,rightChild); //return a new ArithExprNode with operator, leftChild, and rightChild
+        ArithExpNode arithExpNode = new ArithExpNode(operator,leftChild,rightChild);
+        arithExpNode.setLineNumber(parent.getStart().getLine());
+        arithExpNode.setColumnNumber(parent.getStart().getCharPositionInLine());
+        return arithExpNode; //return a new ArithExpNode with operator, leftChild, and rightChild
     }
 
     @Override public AstNode visitFactor(ParLangParser.FactorContext ctx) {
@@ -401,6 +492,9 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitUnaryExp(ParLangParser.UnaryExpContext ctx) {
         UnaryExpNode unaryExpNode = new UnaryExpNode();
+        unaryExpNode.setLineNumber(ctx.getStart().getLine());
+        unaryExpNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+
         if(ctx.getChild(0).getText().equals("-")){ //If the first child is a negation token
             unaryExpNode.setIsNegated(true); //set the node as negated
         }
@@ -411,15 +505,24 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitNumber(ParLangParser.NumberContext ctx) {
         if(ctx.getText().contains(".")){ //If the number is a double
-            return new DoubleNode(Double.parseDouble(ctx.getText())); //parse the number as a double
+            DoubleNode doubleNode = new DoubleNode(Double.parseDouble(ctx.getText()));
+            doubleNode.setLineNumber(ctx.getStart().getLine());
+            doubleNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            return doubleNode; //parse the number as a double
         }else { //If the number is an integer
-            return new IntegerNode(Integer.parseInt(ctx.getText())); //parse the number as an integer
+            IntegerNode integerNode = new IntegerNode(Integer.parseInt(ctx.getText()));
+            integerNode.setLineNumber(ctx.getStart().getLine());
+            integerNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            return integerNode; //parse the number as an integer
         }
     }
 
     @Override public AstNode visitValue(ParLangParser.ValueContext ctx){
         if(ctx.SELF()!=null){//If ValueContext has the terminal node SELF as a chile
-            return new SelfNode(); //return a SelfNode
+            SelfNode selfNode = new SelfNode();
+            selfNode.setLineNumber(ctx.getStart().getLine());
+            selfNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            return selfNode; //return a SelfNode
         }else{//else child is a non-terminal
             return visitChildren(ctx);// visit the non-terminal child
         }
@@ -452,18 +555,25 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
 
     @Override public AstNode visitWhileLoop(ParLangParser.WhileLoopContext ctx) {
         WhileNode whileNode=new WhileNode();
+        whileNode.setLineNumber(ctx.getStart().getLine());
+        whileNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         return childVisitor(whileNode,ctx.children); //visit all children of the whileLoop node and add them as children to the whileNode
     }
 
     @Override public AstNode visitForLoop(ParLangParser.ForLoopContext ctx) {
         ForNode forNode=new ForNode();
+        forNode.setLineNumber(ctx.getStart().getLine());
+        forNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         return childVisitor(forNode,ctx.children); //visit all children of the forLoop node and add them as children to the forNode
     }
     @Override public AstNode visitPrimitive(ParLangParser.PrimitiveContext ctx){
         //Primitives can be: INT, DOUBLE, STRING, and BOOL
         //In case the primitive is a STRING
         if(ctx.STRING() != null) {
-            return new StringNode(ctx.getText());
+            StringNode stringNode = new StringNode(ctx.getText());
+            stringNode.setLineNumber(ctx.getStart().getLine());
+            stringNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+            return stringNode;
         }
         return visitChildren(ctx); //visit all children of the primitive node
     }
@@ -473,6 +583,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
             return visit(ctx.getChild(0)); // Visit the child
         }
         BoolExpNode boolExpNode = new BoolExpNode();
+        boolExpNode.setLineNumber(ctx.getStart().getLine());
+        boolExpNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         for (int i = 0; i < childCount; i += 2) { // Visit all children skipping the operators
             boolExpNode.addChild(visit(ctx.getChild(i))); // Add the child as a child to the boolExprNode
         }
@@ -485,6 +597,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
             return visit(ctx.getChild(0)); // Visit the child
         }
         BoolAndExpNode boolAndExpNode = new BoolAndExpNode();
+        boolAndExpNode.setLineNumber(ctx.getStart().getLine());
+        boolAndExpNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         for (int i = 0; i < childCount; i += 2) { // Visit all children skipping the operators
             boolAndExpNode.addChild(visit(ctx.getChild(i))); // Add the child as a child to the boolAndExpNode
         }
@@ -499,6 +613,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         }
         else { // If there are more than one child
             boolCompareNode = new BoolCompareNode(ctx.getChild(1).getText()); // Create a new node representing the comparison operation
+            boolCompareNode.setLineNumber(ctx.getStart().getLine());
+            boolCompareNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
             // Visit the left-hand side of the comparison and add it as a child
             boolCompareNode.addChild(visit(ctx.boolTerm(0)));
             // Visit the right-hand side of the comparison and add it as a child
@@ -535,6 +651,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override
     public AstNode visitNegatedBool(ParLangParser.NegatedBoolContext ctx) {
         NegatedBoolNode boolNode = new NegatedBoolNode();
+        boolNode.setLineNumber(ctx.getStart().getLine());
+        boolNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         if (ctx.getChild(1).getText().equals("(")) { // !(boolExp)
             AstNode boolExp = visit(ctx.getChild(2)); // Visit the boolean expression
             ((ExpNode)boolExp).setIsParenthesized(true); // Set the boolean expression as parenthesized
@@ -549,7 +667,10 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     public AstNode visitBoolLiteral(ParLangParser.BoolLiteralContext ctx) {
         // contains either 'TRUE' or 'FALSE'
         boolean value = ctx.getText().equals("TRUE"); // Set the value to true if the text is 'TRUE'
-        return new BoolNode(value);
+        BoolNode boolNode = new BoolNode(value);
+        boolNode.setLineNumber(ctx.getStart().getLine());
+        boolNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+        return boolNode;
     }
     @Override
     public AstNode visitCompareExp(ParLangParser.CompareExpContext ctx) {
@@ -563,12 +684,17 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
         String operator = ctx.compareOperator().getText();
 
         // Create a new node representing the comparison operation
-        return new CompareExpNode(operator, leftOperand, rightOperand);
+        CompareExpNode compareExpNode = new CompareExpNode(operator, leftOperand, rightOperand);
+        compareExpNode.setLineNumber(ctx.getStart().getLine());
+        compareExpNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
+        return compareExpNode;
     }
     @Override public AstNode visitArrayAccess(ParLangParser.ArrayAccessContext ctx){
         //An array access
         String accessIdentifier = ctx.identifier().getText();
         ArrayAccessNode node = new ArrayAccessNode("", accessIdentifier);
+        node.setLineNumber(ctx.getStart().getLine());
+        node.setColumnNumber(ctx.getStart().getCharPositionInLine());
         node.setDimensions(ctx.arithExp().size()); //Set the dimensions to number of arithExp children
 
         if(ctx.arithExp(0) !=null){ //Access first child - One dimension so far
@@ -582,11 +708,15 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     }
     @Override public AstNode visitLocalMethodBody(ParLangParser.LocalMethodBodyContext ctx){
         LocalMethodBodyNode methodBodyNode = new LocalMethodBodyNode();
+        methodBodyNode.setLineNumber(ctx.getStart().getLine());
+        methodBodyNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         return childVisitor(methodBodyNode,ctx.children); //visit all children of the localMethodBody node and add them as children to the methodBodyNode
     }
 
     @Override public AstNode visitReturnStatement(ParLangParser.ReturnStatementContext ctx){
         ReturnStatementNode returnStatementNode = new ReturnStatementNode();
+        returnStatementNode.setLineNumber(ctx.getStart().getLine());
+        returnStatementNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         if(ctx.returnType() != null){ //If there is a return value
             returnStatementNode.addChild(visit(ctx.returnType()));
         }
@@ -596,6 +726,8 @@ public class AstVisitor extends ParLangBaseVisitor<AstNode> {
     @Override
     public AstNode visitSelection(ParLangParser.SelectionContext ctx) {
         SelectionNode selectionNode = new SelectionNode();
+        selectionNode.setLineNumber(ctx.getStart().getLine());
+        selectionNode.setColumnNumber(ctx.getStart().getCharPositionInLine());
         childVisitor(selectionNode, ctx.children); //visit all children of the selection node and add them as children to the selectionNode
         return selectionNode; //return the selectionNode
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
@@ -28,7 +28,7 @@ public class MethodVisitor implements NodeVisitor {
         HashMap<String, Attributes> legalLocalMethods = this.symbolTable.getDeclaredLocalMethods();
         //Then we check if the called method is part of that list
         if (!legalLocalMethods.containsKey(node.getMethodName())) {
-            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found"));
+            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
@@ -59,7 +59,7 @@ public class MethodVisitor implements NodeVisitor {
             HashMap<String, Attributes> legalOnMethods = this.symbolTable.getDeclaredOnMethods();
             //We then check if the message is part of the list of allowed messages
             if (!legalOnMethods.containsKey(node.getMsgName())) {
-                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName()));
+                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
             }
 
             //We then leave the scope, such that we do not mess with our scope stack
@@ -67,7 +67,7 @@ public class MethodVisitor implements NodeVisitor {
 
             this.visitChildren(node);
         } catch (NullPointerException e){
-            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found"));
+            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
 
     }
@@ -93,12 +93,12 @@ public class MethodVisitor implements NodeVisitor {
             //We then check if every entry in the Scripts list also is in the Actors list
             for (String onMethod : legalOnMethodsScript.keySet()) {
                 if (!legalOnMethodsActor.containsKey(onMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
                 }
             }
             for(String localMethod : legalLocalMethodsScript.keySet()){
                 if (!legalLocalMethodsActor.containsKey(localMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
                 }
             }
         }

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
@@ -28,7 +28,7 @@ public class MethodVisitor implements NodeVisitor {
         HashMap<String, Attributes> legalLocalMethods = this.symbolTable.getDeclaredLocalMethods();
         //Then we check if the called method is part of that list
         if (!legalLocalMethods.containsKey(node.getMethodName())) {
-            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -59,7 +59,7 @@ public class MethodVisitor implements NodeVisitor {
             HashMap<String, Attributes> legalOnMethods = this.symbolTable.getDeclaredOnMethods();
             //We then check if the message is part of the list of allowed messages
             if (!legalOnMethods.containsKey(node.getMsgName())) {
-                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
 
             //We then leave the scope, such that we do not mess with our scope stack
@@ -67,7 +67,7 @@ public class MethodVisitor implements NodeVisitor {
 
             this.visitChildren(node);
         } catch (NullPointerException e){
-            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
 
     }
@@ -93,12 +93,12 @@ public class MethodVisitor implements NodeVisitor {
             //We then check if every entry in the Scripts list also is in the Actors list
             for (String onMethod : legalOnMethodsScript.keySet()) {
                 if (!legalOnMethodsActor.containsKey(onMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
             for(String localMethod : legalLocalMethodsScript.keySet()){
                 if (!legalLocalMethodsActor.containsKey(localMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
         }

--- a/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/MethodVisitor.java
@@ -28,7 +28,7 @@ public class MethodVisitor implements NodeVisitor {
         HashMap<String, Attributes> legalLocalMethods = this.symbolTable.getDeclaredLocalMethods();
         //Then we check if the called method is part of that list
         if (!legalLocalMethods.containsKey(node.getMethodName())) {
-            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            exceptions.add(new LocalMethodCallException("Local method id " + node.getMethodName() + " not found" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -59,7 +59,7 @@ public class MethodVisitor implements NodeVisitor {
             HashMap<String, Attributes> legalOnMethods = this.symbolTable.getDeclaredOnMethods();
             //We then check if the message is part of the list of allowed messages
             if (!legalOnMethods.containsKey(node.getMsgName())) {
-                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                exceptions.add(new OnMethodCallException("On method id " + node.getMsgName() + " not found in actor: " + symbolTable.getCurrentScope().getScopeName() + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
 
             //We then leave the scope, such that we do not mess with our scope stack
@@ -67,7 +67,7 @@ public class MethodVisitor implements NodeVisitor {
 
             this.visitChildren(node);
         } catch (NullPointerException e){
-            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            exceptions.add(new SymbolNotFoundException("Symbol: " + node.getReceiver() + " not found" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
 
     }
@@ -93,12 +93,12 @@ public class MethodVisitor implements NodeVisitor {
             //We then check if every entry in the Scripts list also is in the Actors list
             for (String onMethod : legalOnMethodsScript.keySet()) {
                 if (!legalOnMethodsActor.containsKey(onMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have on method: " + onMethod + " from Script: " + script.getName() + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
             for(String localMethod : legalLocalMethodsScript.keySet()){
                 if (!legalLocalMethodsActor.containsKey(localMethod)) {
-                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName() + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                    exceptions.add(new MissingOnMethodException("Actor: " + this.symbolTable.findActorParent(node) +  " does not have local method: " + localMethod + " from Script: " + script.getName() + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
         }

--- a/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
@@ -39,7 +39,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Script node are not available outside the Script node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -53,14 +53,14 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertStateSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }else{
             if(this.symbolTable.lookUpSymbolCurrentScope(node.getId()) == null){
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -113,7 +113,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -129,7 +129,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             Attributes attributes = new Attributes(paramNode.getType());
             attributes.setScope(scopeName);
             if(!this.symbolTable.insertParams(paramNode.getName(), attributes)){
-                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -142,7 +142,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Actor node are not available outside the Actor node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -170,12 +170,12 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Checks whether a symbol is a State, Knows or normal symbol and searches the appropriate list
             if(node.getParent().getParent() instanceof StateNode){
                 if(this.symbolTable.lookUpStateSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
                 //Ensures that we do not search for IdentifierNodes for method calls
             }else if (!(node.getParent() instanceof MethodCallNode)){
                 if(this.symbolTable.lookUpSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
         }
@@ -184,21 +184,21 @@ public class SymbolTableVisitor implements NodeVisitor {
     @Override
     public void visit(StateAccessNode node) {
         if(this.symbolTable.lookUpStateSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(ArrayAccessNode node) {
         if(this.symbolTable.lookUpSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(KnowsAccessNode node) {
         if(this.symbolTable.lookUpKnowsSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
 
         this.visitChildren(node);
@@ -213,7 +213,7 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(idChildNode.getType());
                 this.symbolTable.insertKnowsSymbol(idChildNode.getName(), attributes);
             }else{
-                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -235,7 +235,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -246,7 +246,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             this.symbolTable.addActorsFollowingScript(this.symbolTable.findActorParent(node));
             this.symbolTable.leaveScope();
         }else {
-            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
+            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
@@ -39,7 +39,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Script node are not available outside the Script node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists"));
+            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
@@ -53,14 +53,14 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertStateSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node)));
+                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
             }
         }else{
             if(this.symbolTable.lookUpSymbolCurrentScope(node.getId()) == null){
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope"));
+                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -113,7 +113,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node)));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
@@ -129,7 +129,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             Attributes attributes = new Attributes(paramNode.getType());
             attributes.setScope(scopeName);
             if(!this.symbolTable.insertParams(paramNode.getName(), attributes)){
-                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope"));
+                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -142,7 +142,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Actor node are not available outside the Actor node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists"));
+            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
@@ -170,12 +170,12 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Checks whether a symbol is a State, Knows or normal symbol and searches the appropriate list
             if(node.getParent().getParent() instanceof StateNode){
                 if(this.symbolTable.lookUpStateSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node)));
+                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
                 }
                 //Ensures that we do not search for IdentifierNodes for method calls
             }else if (!(node.getParent() instanceof MethodCallNode)){
                 if(this.symbolTable.lookUpSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found"));
+                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
                 }
             }
         }
@@ -184,21 +184,21 @@ public class SymbolTableVisitor implements NodeVisitor {
     @Override
     public void visit(StateAccessNode node) {
         if(this.symbolTable.lookUpStateSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node)));
+            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(ArrayAccessNode node) {
         if(this.symbolTable.lookUpSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found"));
+            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(KnowsAccessNode node) {
         if(this.symbolTable.lookUpKnowsSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node)));
+            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
 
         this.visitChildren(node);
@@ -213,7 +213,7 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(idChildNode.getType());
                 this.symbolTable.insertKnowsSymbol(idChildNode.getName(), attributes);
             }else{
-                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node)));
+                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -235,7 +235,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node)));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 
@@ -246,7 +246,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             this.symbolTable.addActorsFollowingScript(this.symbolTable.findActorParent(node));
             this.symbolTable.leaveScope();
         }else {
-            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found"));
+            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found" + " Line: " + node.getLineNumber() + "Column: " + node.getColumnNumber()));
         }
     }
 

--- a/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/SymbolTableVisitor.java
@@ -39,7 +39,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Script node are not available outside the Script node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Script: " + node.getId() + " already exists" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -53,14 +53,14 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertStateSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("State symbol: " + node.getId() + " already exists in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }else{
             if(this.symbolTable.lookUpSymbolCurrentScope(node.getId()) == null){
                 Attributes attributes = new Attributes(node.getType());
                 this.symbolTable.insertSymbol(node.getId(), attributes);
             }else{
-                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("Symbol " + node.getId() + " already exists in current scope" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -113,7 +113,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -129,7 +129,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             Attributes attributes = new Attributes(paramNode.getType());
             attributes.setScope(scopeName);
             if(!this.symbolTable.insertParams(paramNode.getName(), attributes)){
-                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateSymbolException("Param: " + paramNode.getName() + " already exists in current scope" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -142,7 +142,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the Actor node are not available outside the Actor node
             this.symbolTable.leaveScope();
         }else{
-            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Actor: " + node.getId() + " already exists" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -170,12 +170,12 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Checks whether a symbol is a State, Knows or normal symbol and searches the appropriate list
             if(node.getParent().getParent() instanceof StateNode){
                 if(this.symbolTable.lookUpStateSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                    this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getName() + " not found in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
                 //Ensures that we do not search for IdentifierNodes for method calls
             }else if (!(node.getParent() instanceof MethodCallNode)){
                 if(this.symbolTable.lookUpSymbol(node.getName()) == null){
-                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                    this.exceptions.add(new SymbolNotFoundException("Symbol: "  + node.getName() + " not found" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
                 }
             }
         }
@@ -184,21 +184,21 @@ public class SymbolTableVisitor implements NodeVisitor {
     @Override
     public void visit(StateAccessNode node) {
         if(this.symbolTable.lookUpStateSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("State symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(ArrayAccessNode node) {
         if(this.symbolTable.lookUpSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("Array symbol: "  + node.getAccessIdentifier() + " not found" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
     @Override
     public void visit(KnowsAccessNode node) {
         if(this.symbolTable.lookUpKnowsSymbol(node.getAccessIdentifier()) == null){
-            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new SymbolNotFoundException("Knows symbol: "  + node.getAccessIdentifier() + " not found in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
 
         this.visitChildren(node);
@@ -213,7 +213,7 @@ public class SymbolTableVisitor implements NodeVisitor {
                 Attributes attributes = new Attributes(idChildNode.getType());
                 this.symbolTable.insertKnowsSymbol(idChildNode.getName(), attributes);
             }else{
-                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+                this.exceptions.add(new DuplicateScopeException("Duplicate Knows symbol: " + idChildNode.getName() + " found in Actor: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
             }
         }
     }
@@ -235,7 +235,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             //Leaves the scope after visiting the children, as the variables in the method node are not available outside the method node
             this.symbolTable.leaveScope();
         } else {
-            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node) + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            this.exceptions.add(new DuplicateScopeException("Duplicate Method scope: " + node.getId() + " in Script: " + this.symbolTable.findActorParent(node) + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 
@@ -246,7 +246,7 @@ public class SymbolTableVisitor implements NodeVisitor {
             this.symbolTable.addActorsFollowingScript(this.symbolTable.findActorParent(node));
             this.symbolTable.leaveScope();
         }else {
-            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found" + " Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
+            exceptions.add(new ScopeNotFoundException("Script: " + script.getName() + " not found" + ". Line: " + node.getLineNumber() + " Column: " + node.getColumnNumber()));
         }
     }
 


### PR DESCRIPTION
Also line number and column number to the error messages in SymbolTableVisitor and MethodVisitor.

Line number and column number is still missing for error messages in TypeVisitor, as i wanted to let Emil and Adomas have control over how they want to add it. I will gladly add it if there is no specific way they/we want to make error messages