### PR TITLE
Added type casting for simple types in Code Generation

### DIFF
--- a/generator/input/CodeGen/typeConv.par
+++ b/generator/input/CodeGen/typeConv.par
@@ -1,0 +1,12 @@
+Actor Precision{
+    State{double x; int y}
+    Knows{}
+    Spawn(double x, int y){
+        State.x = x;
+        State.y = y;
+    }
+}
+
+main(){
+    Precision actor = Spawn Precision(3,5);
+}

--- a/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
@@ -577,15 +577,14 @@ public class CodeGenVisitor implements NodeVisitor {
         if (parent instanceof MethodCallNode methodCallNode) {
             String actorType = symbolTable.findActorParent(node);
             String methodName = methodCallNode.getMethodName();
-            Scope actorScope = symbolTable.lookUpScope(methodName + actorType);
-            params = actorScope.getParams();
+            Scope methodScope = symbolTable.lookUpScope(methodName + actorType);
+            params = methodScope.getParams();
         } else if (parent instanceof SpawnActorNode spawnActorNode) {
             //We can call SpawnActor from any scope, hence we have to find the Actor scope where the Spawn we are calling is declared
-            Scope ActorScope = symbolTable.lookUpScope(parent.getType());
+            Scope ActorScope = symbolTable.lookUpScope(spawnActorNode.getType());
             //Within the Actor Scope we enter the spawn scope to get the parameters associated with Spawn
             Scope SpawnScope = ActorScope.children.get(0);
             params = SpawnScope.getParams();
-            String actorName = spawnActorNode.getType();
         } else if (parent instanceof SendMsgNode sendMsgNode) {
             //The first child of SendMsgNode is always a receiver node
             AstNode receiverNode = sendMsgNode.getChildren().get(0);

--- a/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
@@ -117,13 +117,15 @@ public class CodeGenVisitor implements NodeVisitor {
         for (AstNode childNode : node.getChildren()) {
             stringBuilder.append(before);
 
+            //If the children are actual parameters in a call we need to add valueOf() in order for Akka types to work
             if(parameterTypes != null){
-                stringBuilder.append( determineSuffix(parameterTypes.get(index)) + ".valueOf(");
+                stringBuilder.append(determineValue(parameterTypes.get(index)));
             }
 
             childNode.accept(this);
 
-            if(parameterTypes != null){
+            //If we have parameters and the type is either Int or Double, otherwise determineValue returns empty string
+            if(parameterTypes != null && !determineValue(parameterTypes.get(index)).isEmpty()){
                 stringBuilder.append(")");
             }
             stringBuilder.append(after);
@@ -623,10 +625,10 @@ public class CodeGenVisitor implements NodeVisitor {
         return formalParameterTypes;
     }
 
-    private String determineSuffix(String type){
+    private String determineValue(String type){
         return switch (type) {
-            case "int" -> "Long";
-            case "double" -> "Double";
+            case "int" -> "Long.valueOf(";
+            case "double" -> "Double.valueOf(";
             default -> "";
         };
     }

--- a/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
+++ b/generator/src/main/java/org/abcd/examples/ParLang/CodeGenVisitor.java
@@ -516,6 +516,7 @@ public class CodeGenVisitor implements NodeVisitor {
     //4. Write the file
     @Override
     public void visit(ActorDclNode node) {
+        this.symbolTable.enterScope(node.getId());
         resetStringBuilder();
 
         appendPackage();
@@ -541,6 +542,7 @@ public class CodeGenVisitor implements NodeVisitor {
         appendBodyClose();
 
         writeToFile(node.getId(), codeOutput);//Write the actor class to a separate file.
+        this.symbolTable.leaveScope();
     }
 
     private void appendPackage(){
@@ -945,6 +947,7 @@ public class CodeGenVisitor implements NodeVisitor {
 
     @Override
     public void visit(MainDclNode node) {
+        this.symbolTable.enterScope(node.getNodeHash());
         resetStringBuilder();
 
         appendPackage();
@@ -975,6 +978,7 @@ public class CodeGenVisitor implements NodeVisitor {
         visitChildren(node);
         appendBodyClose();
         writeToFile(capitalizeFirstLetter(node.getId()), codeOutput);
+        this.symbolTable.leaveScope();
     }
 
 
@@ -993,6 +997,7 @@ public class CodeGenVisitor implements NodeVisitor {
 
     @Override
     public void visit(MethodDclNode node) {
+        this.symbolTable.enterScope(node.getId() + symbolTable.findActorParent(node));
         if(node.getMethodType().equals(parLangE.ON.getValue())){
             appendInlineComment(parLangE.ON.getValue()," method:"," ",node.getId());
             appendProtocolClass(node);
@@ -1004,6 +1009,7 @@ public class CodeGenVisitor implements NodeVisitor {
             visit(node.getParametersNode());//append parameters in target code
             visit((LocalMethodBodyNode) node.getBodyNode()); //append the method's body in the target code.
         }
+        this.symbolTable.leaveScope();
     }
 
     private void appendInlineComment(String... strings){
@@ -1128,6 +1134,7 @@ public class CodeGenVisitor implements NodeVisitor {
 
     @Override
     public void visit(ScriptDclNode node) {
+        this.symbolTable.enterScope(node.getId());
         resetStringBuilder();
 
         appendPackage();
@@ -1138,6 +1145,7 @@ public class CodeGenVisitor implements NodeVisitor {
         appendBody(node);//The body of the class has a static class for each on-method declared in the script.
 
         writeToFile(node.getId(),codeOutput); //The class is written to a separate file.
+        this.symbolTable.leaveScope();
     }
 
     @Override
@@ -1288,6 +1296,7 @@ public class CodeGenVisitor implements NodeVisitor {
 
     @Override
     public void visit(SpawnDclNode node) {
+        this.symbolTable.enterScope(node.getNodeHash());
         stringBuilder
                 .append(javaE.PUBLIC.getValue())
                 .append(symbolTable.findActorParent(node));
@@ -1295,7 +1304,7 @@ public class CodeGenVisitor implements NodeVisitor {
             stringBuilder.append("()");
         }
         visitChildren(node);
-
+        this.symbolTable.leaveScope();
     }
 
     @Override


### PR DESCRIPTION
For some reason Akka cannot make use of Java built in type casting when calling functions.
Hence, if we want implicit type conversion, we have to lookup type of parameters and type cast them in the java code explicitly.

We decided to place the responsibillity in Code Generation. Since, we could not see how we would have to do it in Type Checking, as we would have to change the AstNode out for a different one based on when a method call occurs.

The added functionality looks up the formal parameters, adds the string of the types to an array. Then calls double.ValueOf() when converting an integer to a double on the actual arguments. Here, we ofcourse trust type checking has done their job properly and we can convert solely based on the parameters. 

I have not implemented type casting Actor to ActorScript, since this is a lot more complex yet.